### PR TITLE
Last Commit

### DIFF
--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -56,7 +56,7 @@ impl<'repo> GitRepository {
         history: Reference<'repo>,
     ) -> Result<GitHistory, GitError> {
         let head = history.peel_to_commit()?;
-        let mut commits = NonEmpty::new(head.clone());
+        let mut commits = Vec::new();
         let mut revwalk = self.0.revwalk()?;
 
         // Set the revwalk to the head commit
@@ -70,7 +70,9 @@ impl<'repo> GitRepository {
             commits.push(commit.clone());
         }
 
-        Ok(vcs::History(commits))
+        NonEmpty::from_slice(&commits)
+            .map(vcs::History)
+            .ok_or(GitError::EmptyCommitHistory)
     }
 }
 

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -324,7 +324,7 @@ impl<'repo> GitBrowser<'repo> {
 
             let tree_entry = commit_tree.get_path(directory_path.as_path()).ok()?;
             let object = tree_entry.to_object(&self.repository.0).ok()?;
-            let tree = object.as_tree().map(|t| t.get_name("main.rs"));
+            let tree = object.as_tree().map(|t| t.get_name(&filename.0));
             tree.map(|_| commit)
         }
     }

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -5,6 +5,19 @@ use git2::{Commit, Error, Oid, Reference, Repository, TreeWalkMode, TreeWalkResu
 use nonempty::NonEmpty;
 use std::collections::HashMap;
 
+#[derive(Debug)]
+pub enum GitError {
+    EmptyCommitHistory,
+    BranchDecode,
+    Internal(Error),
+}
+
+impl From<Error> for GitError {
+    fn from(err: Error) -> Self {
+        GitError::Internal(err)
+    }
+}
+
 /// A `History` that uses `git2::Commit` as the underlying artifact.
 pub type GitHistory<'repo> = vcs::History<Commit<'repo>>;
 

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -331,8 +331,7 @@ impl<'repo> GitBrowser<'repo> {
 
     pub fn last_commit(&self, path: &file_system::Path) -> Option<Commit> {
         self.get_history()
-            .iter()
-            .find_map(|commit| self.commit_contains_path(commit.clone(), path))
+            .find(|commit| self.commit_contains_path(commit.clone(), path))
     }
 }
 

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -116,7 +116,7 @@ impl<'browser, Repo, A, Error> Browser<'browser, Repo, A, Error> {
     /// using the default `History` provided if the operation fails.
     pub fn view_at<F>(&mut self, default_history: History<A>, f: F)
     where
-        A: PartialEq + Clone,
+        A: Clone,
         F: Fn(&History<A>) -> Option<History<A>>,
     {
         self.modify_history(|history| f(history).unwrap_or_else(|| default_history.clone()))

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -36,6 +36,13 @@ impl<A> History<A> {
         new_history.map(History)
     }
 
+    pub fn find<F, B>(&self, f: F) -> Option<B>
+    where
+        F: Fn(&A) -> Option<B>,
+    {
+        self.iter().find_map(f)
+    }
+
     /// Find an atrifact in the given `History` using the artifacts ID.
     ///
     /// This operation may fail if the artifact does not exist in the history.


### PR DESCRIPTION
The main aim of this PR is to add the function `last_commit` onto `GitBrowser`.

This uncovered a bug in `to_history` which double counted the head `Commit` because it was also contained in the `revwalk`. To fix this I used a `Vec` and introduced a `GitError` type, which will be useful for further improvements anyway.

Another addition if `find` on `History` for finding a particular `A` based on a failing operation.

