### PR TITLE
Use git-golden as Golden Files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data/git-golden"]
+	path = data/git-golden
+	url = git@github.com:radicle-dev/git-golden.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data/git-golden"]
 	path = data/git-golden
-	url = git@github.com:radicle-dev/git-golden.git
+	url = https://github.com/radicle-dev/git-golden.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 git2 = "0.10.1"
 nonempty = "0.1.5"
-rm_rf = "0.5.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/data/git-test/Cargo.toml
+++ b/data/git-test/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "git-test"
-version = "0.1.0"
-authors = ["Fintan Halpenny <fintan.halpenny@gmail.com>"]
-edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/data/git-test/src/main.rs
+++ b/data/git-test/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! ```
 //! use radicle_surf::vcs::git::{GitBrowser, GitRepository};
 //! use radicle_surf::file_system::{Label, Path, SystemType};
+//! use pretty_assertions::assert_eq;
 //!
 //! // We're going to point to this repo.
 //! let repo = GitRepository::new(".").unwrap();
@@ -35,9 +36,9 @@
 //!     SystemType::directory(".docker".into()),
 //!     SystemType::directory(".git".into()),
 //!     SystemType::file(".gitignore".into()),
+//!     SystemType::file(".gitmodules".into()),
 //!     SystemType::file("Cargo.toml".into()),
 //!     SystemType::file("README.md".into()),
-//!     SystemType::directory("data".into()),
 //!     SystemType::directory("docs".into()),
 //!     SystemType::directory("src".into()),
 //! ]);

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -278,8 +278,6 @@ impl<'repo> GitBrowser<'repo> {
 mod tests {
     use crate::file_system::*;
     use crate::vcs::git::*;
-    use git2::{IndexAddOption, IntoCString, Signature};
-    use rm_rf;
     use std::panic;
 
     #[test]

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -28,7 +28,7 @@ impl<'repo> GitRepository {
     /// }
     /// ```
     pub fn new(repo_uri: &str) -> Result<Self, Error> {
-        Repository::init(repo_uri).map(GitRepository)
+        Repository::open(repo_uri).map(GitRepository)
     }
 
     pub(crate) fn head(&'repo self) -> Result<GitHistory, Error> {
@@ -282,72 +282,10 @@ mod tests {
     use rm_rf;
     use std::panic;
 
-    fn setup_golden_dir() {
-        // Initialiase the Repository
-        let repo =
-            Repository::init("./data/git-test").expect("Failed to initialise './data/git-test'");
-
-        // Ensure we're in the correct working directory
-        repo.set_workdir(std::path::Path::new("./data/git-test"), true)
-            .expect("Failed to set working dir for './data/git-test'");
-
-        // We have to set up the Index, i.e. staging area
-        let mut index = repo.index().expect("Failed to get index");
-
-        // Add ALL THE FILES
-        index
-            .add_all("*".into_c_string(), IndexAddOption::DEFAULT, None)
-            .expect("add all files failed");
-
-        // Finally, we write the Tree via the Index, i.e. write the files
-        let tree_id = index.write_tree().expect("Failed to write Tree object");
-
-        let signature = Signature::now("monadic.xyz", "test@monadic.xyz")
-            .expect("Failed to initialise signature");
-
-        // Get back the tree we wrote via the Oid
-        let tree = repo
-            .find_tree(tree_id)
-            .expect("Failed to initialise Tree object");
-
-        // FIRST COMMIT!
-        repo.commit(
-            Some("HEAD"),
-            &signature,
-            &signature,
-            "Initial commit",
-            &tree,
-            &[],
-        )
-        .expect("Could not make first commit on './data/git-test'");
-    }
-
-    fn teardown_golden_dir() {
-        rm_rf::ensure_removed("./data/git-test/.git")
-            .expect("Failed to remove '.git' directory in './data/git-test'")
-    }
-
-    fn run_git_test<T>(test: T) -> ()
-    where
-        T: FnOnce() -> () + panic::UnwindSafe,
-    {
-        setup_golden_dir();
-
-        let result = panic::catch_unwind(|| test());
-
-        teardown_golden_dir();
-
-        assert!(result.is_ok())
-    }
-
     #[test]
-    fn run_test_dir() {
-        run_git_test(test_dir)
-    }
-
     fn test_dir() {
-        let repo = GitRepository::new("./data/git-test")
-            .expect("Could not retrieve ./data/git-test as git repository");
+        let repo = GitRepository::new("./data/git-golden")
+            .expect("Could not retrieve ./data/git-golden as git repository");
         let browser = GitBrowser::new(&repo).expect("Could not initialise Browser");
         let directory = browser.get_directory().expect("Could not render Directory");
         let mut directory_contents = directory.list_directory();
@@ -357,7 +295,11 @@ mod tests {
 
         // Root files set up, note that we're ignoring
         // file contents
-        let root_files = NonEmpty::new(File::new("Cargo.toml".into(), &[]));
+        let root_files = (
+            File::new("Cargo.toml".into(), &[]),
+            vec![File::new(".gitignore".into(), &[])],
+        )
+            .into();
         directory_map.insert(Path::root(), root_files);
 
         // src files set up


### PR DESCRIPTION
Turns out submodules are a perfect drop in. `git2` will do the Right Thing:tm: and just treat it like a normal repository in this implementation.