### PR TITLE
Git Objects

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,6 +2,14 @@ env:
   DOCKER_FILE: .docker/build/Dockerfile
 
 steps:
+- label: "Submodule Fetch Remote"
+  command: git submodule foreach "git fetch origin"
+  agents:
+    production: "true"
+    platform: "linux"
+
+- wait
+
 - label: "Tests"
   command: "cargo test --all"
   agents:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,14 +4,14 @@ env:
 steps:
 - label: "Submodule Fetch Remote"
   command: git submodule foreach "git fetch origin"
+  key: "submodule-fetch"
   agents:
     production: "true"
     platform: "linux"
 
-- wait
-
 - label: "Tests"
   command: "cargo test --all"
+  depends_on: "submodule-fetch"
   agents:
     production: "true"
     platform: "linux"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,15 +2,11 @@ env:
   DOCKER_FILE: .docker/build/Dockerfile
 
 steps:
-- label: "Submodule Fetch Remote"
-  command: git submodule foreach "git fetch origin"
-  key: "submodule-fetch"
-  agents:
-    production: "true"
-    platform: "linux"
-
 - label: "Tests"
-  command: "cargo test --all"
+  command:
+  # Ensure we have fetched the remote info in submodule
+  - git submodule foreach "git fetch origin"
+  - "cargo test --all"
   depends_on: "submodule-fetch"
   agents:
     production: "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,4 +1,5 @@
 env:
+  DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-surf-build:8c5e5e90064cb89f5faeedfe2874cbc3efbe260c"
   DOCKER_FILE: .docker/build/Dockerfile
 
 steps:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -8,7 +8,6 @@ steps:
   # Ensure we have fetched the remote info in submodule
   - git submodule foreach "git fetch origin"
   - "cargo test --all"
-  depends_on: "submodule-fetch"
   agents:
     production: "true"
     platform: "linux"

--- a/.docker/build/Dockerfile
+++ b/.docker/build/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
         pkg-config \
         jq \
         curl \
+        git \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ let browser = GitBrowser::new(&repo).unwrap();
 let directory = browser.get_directory().unwrap();
 
 // Let's get a Path to this file
-let this_file = Path::from_labels(Label::root(), &["src".into(), "lib.rs".into()]);
+let this_file = Path::with_root(&["src".into(), "lib.rs".into()]);
 
 // And assert that we can find it!
 assert!(directory.find_file(&this_file).is_some());
@@ -46,7 +46,7 @@ assert_eq!(root_contents, vec![
   SystemType::directory("src".into()),
 ]);
 
-let src = directory.find_directory(&Path::from_labels(Label::root(), &["src".into()])).unwrap();
+let src = directory.find_directory(&Path::with_root(&["src".into()])).unwrap();
 let mut src_contents = src.list_directory();
 src_contents.sort();
 

--- a/src/file_system/mod.rs
+++ b/src/file_system/mod.rs
@@ -97,7 +97,7 @@ impl Path {
     /// use radicle_surf::file_system::{Label, Path};
     ///
     /// let root = Path::root();
-    /// let not_root = Path::from_labels(Label::root(), &["src".into(), "lib.rs".into()]);
+    /// let not_root = Path::with_root(&["src".into(), "lib.rs".into()]);
     ///
     /// assert!(root.is_root());
     /// assert!(!not_root.is_root());
@@ -133,7 +133,7 @@ impl Path {
     /// root.push("src".into());
     /// root.push("lib.rs".into());
     ///
-    /// assert_eq!(root, Path::from_labels(Label::root(), &["src".into(), "lib.rs".into()]));
+    /// assert_eq!(root, Path::with_root(&["src".into(), "lib.rs".into()]));
     /// ```
     pub fn push(&mut self, label: Label) {
         self.0.push(label)
@@ -146,7 +146,7 @@ impl Path {
     /// ```
     /// use radicle_surf::file_system::{Label, Path};
     ///
-    /// let path = Path::from_labels(Label::root(), &["src".into(), "lib.rs".into()]);
+    /// let path = Path::with_root(&["src".into(), "lib.rs".into()]);
     /// let mut path_iter = path.iter();
     ///
     /// assert_eq!(path_iter.next(), Some(&Label::root()));
@@ -165,7 +165,7 @@ impl Path {
     /// ```
     /// use radicle_surf::file_system::{Label, Path};
     ///
-    /// let path = Path::from_labels(Label::root(), &["src".into(), "lib.rs".into()]);
+    /// let path = Path::with_root(&["src".into(), "lib.rs".into()]);
     ///
     /// assert_eq!(path.split_first(), (&Label::root(), &["src".into(), "lib.rs".into()][..]));
     /// ```
@@ -191,7 +191,7 @@ impl Path {
     /// ```
     /// use radicle_surf::file_system::{Label, Path};
     ///
-    /// let path = Path::from_labels(Label::root(), &["src".into(), "lib.rs".into()]);
+    /// let path = Path::with_root(&["src".into(), "lib.rs".into()]);
     /// assert_eq!(path.split_last(), (vec![Label::root(), "src".into()], "lib.rs".into()));
     /// ```
     ///
@@ -233,7 +233,7 @@ impl Path {
     /// use radicle_surf::file_system::{Path, Label};
     /// use nonempty::NonEmpty;
     ///
-    /// let path = Path::from_labels(Label::root(), &["foo".into(), "bar".into(), "baz.rs".into()]);
+    /// let path = Path::with_root(&["foo".into(), "bar".into(), "baz.rs".into()]);
     ///
     /// let mut expected = Path::root();
     /// expected.push("foo".into());
@@ -246,6 +246,30 @@ impl Path {
     /// ```
     pub fn from_labels(root: Label, labels: &[Label]) -> Path {
         Path((root, labels.to_vec()).into())
+    }
+
+    /// Construct a `Path` using [`Label::root`](struct.Label.html#method.root)
+    /// as the head of the `Path.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use radicle_surf::file_system::{Path, Label};
+    /// use nonempty::NonEmpty;
+    ///
+    /// let path = Path::with_root(&["foo".into(), "bar".into(), "baz.rs".into()]);
+    ///
+    /// let mut expected = Path::root();
+    /// expected.push("foo".into());
+    /// expected.push("bar".into());
+    /// expected.push("baz.rs".into());
+    ///
+    /// assert_eq!(path, expected);
+    /// let path_vec: Vec<Label> = path.0.into();
+    /// assert_eq!(path_vec, vec!["~".into(), "foo".into(), "bar".into(), "baz.rs".into()]);
+    /// ```
+    pub fn with_root(labels: &[Label]) -> Path {
+        Path::from_labels(Label::root(), labels)
     }
 
     /// Convert a raw string literal to a `Path`.
@@ -753,7 +777,7 @@ pub mod tests {
 
     #[test]
     fn test_find_added_file() {
-        let file_path = Path::from_labels(Label::root(), &["foo.hs".into()]);
+        let file_path = Path::with_root(&["foo.hs".into()]);
 
         let file = File::new("foo.hs".into(), b"module Banana ...");
 
@@ -768,10 +792,7 @@ pub mod tests {
 
     #[test]
     fn test_find_added_file_long_path() {
-        let file_path = Path::from_labels(
-            Label::root(),
-            &["foo".into(), "bar".into(), "baz.hs".into()],
-        );
+        let file_path = Path::with_root(&["foo".into(), "bar".into(), "baz.hs".into()]);
 
         let file = File::new("baz.hs".into(), b"module Banana ...");
 
@@ -792,7 +813,7 @@ pub mod tests {
 
     #[test]
     fn test_404_file_not_found() {
-        let file_path = Path::from_labels(Label::root(), &["bar.hs".into()]);
+        let file_path = Path::with_root(&["bar.hs".into()]);
 
         let directory: Directory = Directory {
             label: Label::root(),
@@ -863,7 +884,7 @@ pub mod tests {
         );
 
         let sub_directory = directory
-            .find_directory(&Path::from_labels("~".into(), &["haskell".into()]))
+            .find_directory(&Path::with_root(&["haskell".into()]))
             .unwrap();
         let mut sub_directory_contents = sub_directory.list_directory();
         sub_directory_contents.sort();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! let directory = browser.get_directory().unwrap();
 //!
 //! // Let's get a Path to this file
-//! let this_file = Path::from_labels(Label::root(), &["src".into(), "lib.rs".into()]);
+//! let this_file = Path::with_root(&["src".into(), "lib.rs".into()]);
 //!
 //! // And assert that we can find it!
 //! assert!(directory.find_file(&this_file).is_some());
@@ -43,7 +43,7 @@
 //!     SystemType::directory("src".into()),
 //! ]);
 //!
-//! let src = directory.find_directory(&Path::from_labels(Label::root(), &["src".into()])).unwrap();
+//! let src = directory.find_directory(&Path::with_root(&["src".into()])).unwrap();
 //! let mut src_contents = src.list_directory();
 //! src_contents.sort();
 //!

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -63,9 +63,9 @@ pub struct GitRepository(pub(crate) Repository);
 impl<'repo> GitRepository {
     /// Open a git repository given its URI.
     ///
-    /// # Example
+    /// # Examples
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, GitRepository};
+    /// use radicle_surf::vcs::git::{BranchName, GitBrowser, GitRepository};
     ///
     /// let repo = GitRepository::new("./data/git-golden").unwrap();
     /// let browser = GitBrowser::new(&repo).unwrap();
@@ -75,10 +75,10 @@ impl<'repo> GitRepository {
     /// assert_eq!(
     ///     branches,
     ///     Ok(vec![
-    ///         "master".into(),
-    ///         "origin/HEAD".into(),
-    ///         "origin/add-tests".into(),
-    ///         "origin/master".into()
+    ///         BranchName::new("master"),
+    ///         BranchName::new("origin/HEAD"),
+    ///         BranchName::new("origin/add-tests"),
+    ///         BranchName::new("origin/master"),
     ///     ])
     /// );
     /// ```
@@ -88,14 +88,24 @@ impl<'repo> GitRepository {
             .map_err(GitError::from)
     }
 
-    pub(crate) fn head(&'repo self) -> Result<GitHistory, GitError> {
-        let head = self.0.head()?;
-        self.to_history(head)
+    /// Get a particular `Commit`.
+    pub(crate) fn get_commit(&'repo self, sha: Sha1) -> Result<Commit<'repo>, GitError> {
+        let oid = Oid::from_str(&sha.0)?;
+        let commit = self.0.find_commit(oid)?;
+        Ok(commit)
     }
 
+    /// Build a `GitHistory` using the `head` reference.
+    pub(crate) fn head(&'repo self) -> Result<GitHistory, GitError> {
+        let head = self.0.head()?;
+        self.to_history(&head)
+    }
+
+    /// Turn a `git2::Reference` into a `GitHistory` by completing
+    /// a revwalk over the first commit in the reference.
     pub(crate) fn to_history(
         &'repo self,
-        history: Reference<'repo>,
+        history: &Reference<'repo>,
     ) -> Result<GitHistory, GitError> {
         let head = history.peel_to_commit()?;
         let mut commits = Vec::new();
@@ -128,15 +138,98 @@ impl<'repo> vcs::GetVCS<'repo, GitError> for GitRepository {
     }
 }
 
+/// A newtype wrapper over `String` to separate out
+/// the fact that a caller wants to fetch a branch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BranchName(String);
+
+impl BranchName {
+    pub fn new(name: &str) -> Self {
+        BranchName(name.into())
+    }
+
+    pub fn name(&self) -> String {
+        self.0.clone()
+    }
+}
+
+/// A newtype wrapper over `String` to separate out
+/// the fact that a caller wants to fetch a tag.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TagName(String);
+
+impl TagName {
+    pub fn new(name: &str) -> Self {
+        TagName(name.into())
+    }
+
+    pub fn name(&self) -> String {
+        self.0.clone()
+    }
+}
+
+/// A newtype wrapper over `String` to separate out
+/// the fact that a caller wants to fetch a commit.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Sha1(String);
+
+impl Sha1 {
+    pub fn new(name: &str) -> Self {
+        Sha1(name.into())
+    }
+
+    pub fn name(&self) -> String {
+        self.0.clone()
+    }
+}
+
+/// An enumeration of git objects we can fetch and turn
+/// into a [`GitHistory`](struct.GitHistory.html).
+#[derive(Debug, Clone)]
+pub enum GitObject {
+    Branch(BranchName),
+    Tag(TagName),
+}
+
+impl GitObject {
+    pub fn branch(name: &str) -> Self {
+        GitObject::Branch(BranchName::new(name))
+    }
+
+    pub fn tag(name: &str) -> Self {
+        GitObject::Tag(TagName::new(name))
+    }
+
+    fn get_name(&self) -> String {
+        match self {
+            GitObject::Branch(name) => name.0.clone(),
+            GitObject::Tag(name) => name.0.clone(),
+        }
+    }
+}
+
 impl<'repo> vcs::VCS<'repo, Commit<'repo>, GitError> for GitRepository {
-    type HistoryId = &'repo str;
+    type HistoryId = GitObject;
     type ArtefactId = Oid;
 
     fn get_history(&'repo self, history_id: Self::HistoryId) -> Result<GitHistory, GitError> {
-        self.0
-            .resolve_reference_from_short_name(&history_id)
-            .map_err(GitError::from)
-            .and_then(|reference| self.to_history(reference))
+        let reference = self
+            .0
+            .resolve_reference_from_short_name(&history_id.get_name())?;
+        let to_history = |pred, err| {
+            if pred {
+                self.to_history(&reference)
+            } else {
+                Err(err)
+            }
+        };
+        match history_id {
+            GitObject::Branch(_) => to_history(
+                reference.is_branch() || reference.is_remote(),
+                GitError::NotBranch,
+            ),
+            GitObject::Tag(_) => to_history(reference.is_tag(), GitError::NotTag),
+        }
     }
 
     fn get_histories(&'repo self) -> Result<Vec<GitHistory>, GitError> {
@@ -146,7 +239,7 @@ impl<'repo> vcs::VCS<'repo, Commit<'repo>, GitError> for GitRepository {
             .and_then(|mut references| {
                 references.try_fold(vec![], |mut acc, reference| {
                     reference.map_err(GitError::from).and_then(|r| {
-                        let history = self.to_history(r)?;
+                        let history = self.to_history(&r)?;
                         acc.push(history);
                         Ok(acc)
                     })
@@ -174,23 +267,20 @@ impl std::fmt::Debug for GitRepository {
     }
 }
 
-/// A `Browser` that uses `GitRepository` as the underlying repository backend,
-/// `git2::Commit` as the artifact, and `git2::Error` for error reporting.
+/// A `Browser` that uses [`GitRepository`](struct.GitRepository.html) as the underlying repository backend,
+/// `git2::Commit` as the artifact, and [`GitError`](enum.GitError.html) for error reporting.
 pub type GitBrowser<'repo> = vcs::Browser<'repo, GitRepository, Commit<'repo>, GitError>;
 
 impl<'repo> GitBrowser<'repo> {
     /// Create a new browser to interact with.
     ///
-    /// # Example
+    /// # Examples
+    ///
     /// ```
     /// use radicle_surf::vcs::git::{GitBrowser, GitRepository};
     ///
-    /// let repo = GitRepository::new(".").unwrap();
+    /// let repo = GitRepository::new("./data/git-golden").unwrap();
     /// let browser = GitBrowser::new(&repo).unwrap();
-    ///
-    /// for branch in browser.list_tags().unwrap() {
-    ///     println!("Branch: {}", branch);
-    /// }
     /// ```
     pub fn new(repository: &'repo GitRepository) -> Result<Self, GitError> {
         let history = repository.head()?;
@@ -205,14 +295,14 @@ impl<'repo> GitBrowser<'repo> {
         })
     }
 
-    /// Set the current `GitBrowser` history to the
-    /// HEAD commit of the underlying repository.
+    /// Set the current `GitBrowser` history to the `HEAD` commit of the underlying repository.
     ///
-    /// # Example
+    /// # Examples
+    ///
     /// ```
     /// use radicle_surf::vcs::git::{GitBrowser, GitRepository};
     ///
-    /// let repo = GitRepository::new(".").unwrap();
+    /// let repo = GitRepository::new("./data/git-golden").unwrap();
     /// let mut browser = GitBrowser::new(&repo).unwrap();
     ///
     /// // ensure we're at HEAD
@@ -229,10 +319,11 @@ impl<'repo> GitBrowser<'repo> {
         Ok(())
     }
 
-    /// Set the current `GitBrowser` history to the
-    /// branch name provided.
+    /// Set the current `GitBrowser` history to the [`BranchName`](struct.BranchName.html)
+    /// provided.
     ///
     /// # Examples
+    ///
     /// ```
     /// use radicle_surf::vcs::git::{BranchName, GitBrowser, GitRepository};
     ///
@@ -247,28 +338,143 @@ impl<'repo> GitBrowser<'repo> {
     /// // We are able to render the directory
     /// assert!(directory.is_ok());
     /// ```
-    pub fn branch(&mut self, branch_name: &'repo str) -> Result<(), GitError> {
-        let branch = self.repository.get_history(branch_name)?;
+    ///
+    /// ```
+    /// use radicle_surf::vcs::git::{BranchName, GitBrowser, GitRepository};
+    /// use radicle_surf::file_system::{Label, Path, SystemType};
+    ///
+    /// let repo = GitRepository::new("./data/git-golden").unwrap();
+    /// let mut browser = GitBrowser::new(&repo).unwrap();
+    /// browser
+    ///     .branch(BranchName::new("origin/add-tests"))
+    ///     .expect("Failed to change branch to add-tests");
+    ///
+    /// let directory = browser.get_directory().expect("Failed to get directory");
+    /// let mut directory_contents = directory.list_directory();
+    /// directory_contents.sort();
+    ///
+    /// assert_eq!(
+    ///     directory_contents,
+    ///     vec![
+    ///         SystemType::directory(".git".into()),
+    ///         SystemType::file(".gitignore".into()),
+    ///         SystemType::file("Cargo.toml".into()),
+    ///         SystemType::directory("src".into()),
+    ///         SystemType::directory("tests".into()),
+    ///     ]
+    /// );
+    ///
+    /// let tests = directory
+    ///     .find_directory(&Path::from_labels(Label::root(), &["tests".into()]))
+    ///     .expect("tests not found");
+    /// let mut tests_contents = tests.list_directory();
+    /// tests_contents.sort();
+    ///
+    /// assert_eq!(
+    ///     tests_contents,
+    ///     vec![SystemType::file("mod.rs".into())]
+    /// );
+    /// ```
+    pub fn branch(&mut self, branch_name: BranchName) -> Result<(), GitError> {
+        let branch = self
+            .repository
+            .get_history(GitObject::Branch(branch_name))?;
         self.set_history(branch);
         Ok(())
     }
 
-    /// List the names of the branches that are contained in the
-    /// underlying `GitRepository`.
+    /// Set the current `GitBrowser` history to the [`TagName`](struct.TagName.html)
+    /// provided.
     ///
-    /// # Example
+    /// # Examples
+    ///
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, GitRepository};
+    /// use git2::Oid;
+    /// use radicle_surf::vcs::History;
+    /// use radicle_surf::vcs::git::{TagName, GitBrowser, GitRepository};
     ///
-    /// let repo = GitRepository::new(".").unwrap();
+    /// let repo = GitRepository::new("./data/git-golden").unwrap();
+    /// let mut browser = GitBrowser::new(&repo).unwrap();
+    ///
+    /// // Switch to "v0.0.1"
+    /// browser.tag(TagName::new("v0.0.1"));
+    ///
+    /// let expected_history = History((
+    ///     Oid::from_str("74ba370ee5643f310873fb288af1c99d639da8ca").unwrap(),
+    ///     vec![
+    ///         Oid::from_str("8eb5ace23086a588200d9aae1374f46c346bccec").unwrap(),
+    ///         Oid::from_str("cd3971c01606a0b1df2f3429aeb5766d234d7893").unwrap(),
+    ///     ]
+    /// ).into());
+    ///
+    /// let history_ids = browser.get_history().map(|commit| commit.id());
+    ///
+    /// // We are able to render the directory
+    /// assert_eq!(history_ids, expected_history);
+    /// ```
+    pub fn tag(&mut self, tag_name: TagName) -> Result<(), GitError> {
+        let branch = self.repository.get_history(GitObject::Tag(tag_name))?;
+        self.set_history(branch);
+        Ok(())
+    }
+
+    /// Set the current `GitBrowser` history to the [`Sha1`](struct.Sha1.html)
+    /// provided. The history will consist of a single [`Commit`](struct.Commit.html).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use radicle_surf::file_system::SystemType;
+    /// use radicle_surf::vcs::git::{GitBrowser, GitRepository, Sha1};
+    ///
+    /// let repo = GitRepository::new("./data/git-golden")
+    ///     .expect("Could not retrieve ./data/git-golden as git repository");
+    /// let mut browser = GitBrowser::new(&repo).expect("Could not initialise Browser");
+    ///
+    /// // Set to the initial commit
+    /// browser
+    ///     .commit(Sha1::new("cd3971c01606a0b1df2f3429aeb5766d234d7893"))
+    ///     .unwrap();
+    ///
+    /// let directory = browser.get_directory().unwrap();
+    /// let mut directory_contents = directory.list_directory();
+    /// directory_contents.sort();
+    ///
+    /// // We should only have src and .git in our root
+    /// assert_eq!(
+    ///     directory_contents,
+    ///     vec![
+    ///         SystemType::directory(".git".into()),
+    ///         SystemType::directory("src".into()),
+    ///     ]
+    /// );
+    ///
+    /// // We have the single commit
+    /// assert!(browser.get_history().0.len() == 1);
+    /// ```
+    pub fn commit(&mut self, sha: Sha1) -> Result<(), GitError> {
+        let commit = self.repository.get_commit(sha)?;
+        self.set_history(vcs::History(NonEmpty::new(commit)));
+        Ok(())
+    }
+
+    /// List the names of the branches that are contained in the
+    /// underlying [`GitRepository`](struct.GitRepository.hmtl).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use radicle_surf::vcs::git::{BranchName, GitBrowser, GitRepository};
+    ///
+    /// let repo = GitRepository::new("./data/git-golden").unwrap();
     /// let mut browser = GitBrowser::new(&repo).unwrap();
     ///
     /// let branches = browser.list_branches().unwrap();
     ///
     /// // 'master' exists in the list of branches
-    /// assert!(branches.contains(&"master".to_string()));
+    /// assert!(branches.contains(&BranchName::new("master")));
     /// ```
-    pub fn list_branches(&self) -> Result<Vec<String>, GitError> {
+    pub fn list_branches(&self) -> Result<Vec<BranchName>, GitError> {
         self.repository
             .0
             .branches(None)
@@ -278,7 +484,7 @@ impl<'repo> GitBrowser<'repo> {
                     let (branch, _) = branch?;
                     let branch_name = branch.name()?;
                     if let Some(name) = branch_name {
-                        acc.push(name.to_string());
+                        acc.push(BranchName(name.to_string()));
                         Ok(acc)
                     } else {
                         Err(GitError::BranchDecode)
@@ -288,9 +494,9 @@ impl<'repo> GitBrowser<'repo> {
     }
 
     /// List the names of the tags that are contained in the
-    /// underlying `GitRepository`.
+    /// underlying [`GitRepository`](struct.GitRepository.hmtl).
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use radicle_surf::vcs::git::{GitBrowser, GitRepository};
     ///
@@ -304,7 +510,7 @@ impl<'repo> GitBrowser<'repo> {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, GitRepository};
+    /// use radicle_surf::vcs::git::{GitBrowser, GitRepository, TagName};
     ///
     /// let repo = GitRepository::new("./data/git-golden").unwrap();
     /// let mut browser = GitBrowser::new(&repo).unwrap();
@@ -312,13 +518,13 @@ impl<'repo> GitBrowser<'repo> {
     /// let tags = browser.list_tags().unwrap();
     ///
     /// // We currently have no tags :(
-    /// assert_eq!(tags, vec!["v0.0.1"]);
+    /// assert_eq!(tags, vec![TagName::new("v0.0.1")]);
     /// ```
-    pub fn list_tags(&self) -> Result<Vec<String>, GitError> {
+    pub fn list_tags(&self) -> Result<Vec<TagName>, GitError> {
         let tags = self.repository.0.tag_names(None)?;
         Ok(tags
             .into_iter()
-            .filter_map(|tag| tag.map(String::from))
+            .filter_map(|tag| tag.map(TagName::new))
             .collect())
     }
 

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -37,10 +37,12 @@ use git2::{Commit, Error, Oid, Reference, Repository, TreeWalkMode, TreeWalkResu
 use nonempty::NonEmpty;
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum GitError {
     EmptyCommitHistory,
     BranchDecode,
+    NotBranch,
+    NotTag,
     Internal(Error),
 }
 

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -20,7 +20,7 @@
 //!
 //! // find src directory in the Git directory and the in-memory directory
 //! let src_directory = directory
-//!     .find_directory(&Path::from_labels("~".into(), &["src".into()]))
+//!     .find_directory(&Path::with_root(&["src".into()]))
 //!     .unwrap();
 //! let mut src_directory_contents = src_directory.list_directory();
 //! src_directory_contents.sort();
@@ -365,7 +365,7 @@ impl<'repo> GitBrowser<'repo> {
     /// );
     ///
     /// let tests = directory
-    ///     .find_directory(&Path::from_labels(Label::root(), &["tests".into()]))
+    ///     .find_directory(&Path::with_root(&["tests".into()]))
     ///     .expect("tests not found");
     /// let mut tests_contents = tests.list_directory();
     /// tests_contents.sort();
@@ -544,16 +544,13 @@ impl<'repo> GitBrowser<'repo> {
     /// let head_commit = browser.get_history().0.first().clone();
     ///
     /// let toml_last_commit = browser
-    ///     .last_commit(&Path::from_labels(Label::root(), &["Cargo.toml".into()]))
+    ///     .last_commit(&Path::with_root(&["Cargo.toml".into()]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(toml_last_commit, Some(head_commit.id()));
     ///
     /// let main_last_commit = browser
-    ///     .last_commit(&Path::from_labels(
-    ///         Label::root(),
-    ///         &["src".into(), "main.rs".into()],
-    ///     ))
+    ///     .last_commit(&Path::with_root(&["src".into(), "main.rs".into()]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(main_last_commit, Some(head_commit.id()));
@@ -574,17 +571,14 @@ impl<'repo> GitBrowser<'repo> {
     ///
     /// // Cargo.toml is commited second so it should not exist here.
     /// let toml_last_commit = browser
-    ///     .last_commit(&Path::from_labels(Label::root(), &["Cargo.toml".into()]))
+    ///     .last_commit(&Path::with_root(&["Cargo.toml".into()]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(toml_last_commit, None);
     ///
     /// // src/main.rs exists in this commit.
     /// let main_last_commit = browser
-    ///     .last_commit(&Path::from_labels(
-    ///         Label::root(),
-    ///         &["src".into(), "main.rs".into()],
-    ///     ))
+    ///     .last_commit(&Path::with_root(&["src".into(), "main.rs".into()]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(main_last_commit, Some(head_commit.id()));

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -6,7 +6,7 @@ pub mod git;
 /// A non-empty bag of artifacts which are used to
 /// derive a `Directory` view. Examples of artifacts
 /// would be commits in Git or patches in Pijul.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct History<A>(pub NonEmpty<A>);
 
 impl<A> History<A> {

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -36,6 +36,13 @@ impl<A> History<A> {
         new_history.map(History)
     }
 
+    pub fn map<F, B>(&self, f: F) -> History<B>
+    where
+        F: Fn(&A) -> B,
+    {
+        History(self.0.map(f))
+    }
+
     pub fn find<F, B>(&self, f: F) -> Option<B>
     where
         F: Fn(&A) -> Option<B>,


### PR DESCRIPTION
This PR introduces more ergonomics around git objects. I also snuck in some testing reorg and saw a pattern with `Path::from_labels(Label::root, labels)`.

Main thing is that there is:
* Wrappers around `String` for differentiating what the user wants to fetch
  * `BranchName`
  * `TagName`
  * `Sha1` 
* `GitObject` an enumeration of `Branch` and `Tag` to specify what we're fetching specifically. 
* Functions on `GitBrowser` for setting the `History`
  * `branch`
  * `tag`
  * `commit`