### PR TITLE
Reexport git2 dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,3 @@ pub mod file_system;
 pub mod vcs;
 
 pub use crate::vcs::git;
-
-pub use git2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,3 +60,5 @@ pub mod file_system;
 pub mod vcs;
 
 pub use crate::vcs::git;
+
+pub use git2;

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -30,6 +30,8 @@
 //! ]);
 //! ```
 
+pub use git2;
+
 use crate::file_system;
 use crate::vcs;
 use crate::vcs::VCS;


### PR DESCRIPTION
A lot of the git based implementations return git2 types, having the crate re-exported makes it safer for consumers to depend on them while depending on the same version.