### PR TITLE
Hide RepoBackend directories

### DIFF
--- a/src/file_system/mod.rs
+++ b/src/file_system/mod.rs
@@ -358,11 +358,11 @@ where
     /// use nonempty::NonEmpty;
     ///
     /// let repo = Directory {
-    ///     label: Label::root(),
+    ///     name: Label::root(),
     ///     entries: NonEmpty::new(
     ///         DirectoryContents::SubDirectory(Box::new(
     ///             Directory {
-    ///                 label: ".git".into(),
+    ///                 name: ".git".into(),
     ///                 entries: NonEmpty::new(DirectoryContents::Repo),
     ///             }
     ///         ))
@@ -394,7 +394,7 @@ impl DirectoryContents {
     /// use radicle_surf::file_system::{File, Directory, DirectoryContents};
     ///
     /// let lib = Directory {
-    ///     label: "src".into(),
+    ///     name: "src".into(),
     ///     entries: NonEmpty::new(DirectoryContents::File(File::new(
     ///         "lib.rs".into(),
     ///         b"pub mod file_system;",
@@ -418,7 +418,7 @@ impl DirectoryContents {
     /// use radicle_surf::file_system::{File, Directory, DirectoryContents};
     ///
     /// let lib = Directory {
-    ///     label: "src".into(),
+    ///     name: "src".into(),
     ///     entries: NonEmpty::new(DirectoryContents::file("lib.rs".into(), b"pub mod file_system;")),
     /// };
     ///
@@ -426,15 +426,15 @@ impl DirectoryContents {
     ///
     /// assert_eq!(sub_dir, DirectoryContents::SubDirectory(Box::new(lib)));
     /// ```
-    pub fn file(filename: Label, contents: &[u8]) -> Self {
-        DirectoryContents::File(File::new(filename, contents))
+    pub fn file(name: Label, contents: &[u8]) -> Self {
+        DirectoryContents::File(File::new(name, contents))
     }
 
     pub fn label(&self) -> Option<&Label> {
         match self {
-            DirectoryContents::SubDirectory(dir) => Some(&dir.label),
-            DirectoryContents::File(file) => Some(&file.filename),
-            _ => None,
+            DirectoryContents::SubDirectory(dir) => Some(&dir.name),
+            DirectoryContents::File(file) => Some(&file.name),
+            DirectoryContents::Repo => None,
         }
     }
 }
@@ -445,7 +445,7 @@ impl DirectoryContents {
 /// This is because empty directories do not generally exist in VCSes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Directory {
-    pub label: Label,
+    pub name: Label,
     pub entries: NonEmpty<DirectoryContents>,
 }
 
@@ -453,16 +453,16 @@ pub struct Directory {
 /// and its file contents (a `Vec` of bytes).
 #[derive(Clone, PartialEq, Eq)]
 pub struct File {
-    pub filename: Label,
+    pub name: Label,
     pub contents: Vec<u8>,
     pub(crate) size: usize,
 }
 
 impl File {
-    pub fn new(filename: Label, contents: &[u8]) -> Self {
+    pub fn new(name: Label, contents: &[u8]) -> Self {
         let size = contents.len();
         File {
-            filename,
+            name,
             contents: contents.to_vec(),
             size,
         }
@@ -496,7 +496,7 @@ impl File {
 
 impl std::fmt::Debug for File {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "File {{ filename: {:#?} }}", self.filename)
+        write!(f, "File {{ name: {:#?} }}", self.name)
     }
 }
 
@@ -548,7 +548,7 @@ impl Directory {
     /// ).into();
     ///
     /// let directory = Directory {
-    ///     label: Label::root(),
+    ///     name: Label::root(),
     ///     entries: files,
     /// };
     ///
@@ -565,7 +565,7 @@ impl Directory {
     /// ).into();
     ///
     /// let subdir = DirectoryContents::sub_directory(Directory {
-    ///     label: "test".into(),
+    ///     name: "test".into(),
     ///     entries: NonEmpty::new(DirectoryContents::file(
     ///         "mod.rs".into(),
     ///         b"assert_eq!(1 + 1, 2);",
@@ -575,7 +575,7 @@ impl Directory {
     /// entries.push(subdir);
     ///
     /// let directory = Directory {
-    ///     label: Label::root(),
+    ///     name: Label::root(),
     ///     entries: entries,
     /// };
     ///
@@ -598,8 +598,8 @@ impl Directory {
             .iter()
             .cloned()
             .filter_map(|entry| match entry {
-                DirectoryContents::SubDirectory(dir) => Some(SystemType::directory(dir.label)),
-                DirectoryContents::File(file) => Some(SystemType::file(file.filename)),
+                DirectoryContents::SubDirectory(dir) => Some(SystemType::directory(dir.name)),
+                DirectoryContents::File(file) => Some(SystemType::file(file.name)),
                 DirectoryContents::Repo => None,
             })
             .collect()
@@ -615,13 +615,13 @@ impl Directory {
     /// This operation fails if the path does not lead to
     /// the `File`.
     pub fn find_file(&self, path: &Path) -> Option<File> {
-        let (path, filename) = path.split_last();
+        let (path, name) = path.split_last();
         let path = NonEmpty::from_slice(&path);
 
         // Find the file in the current directoy if the prefix path is empty.
         // Otherwise find it in the directory found in the given path (if it exists).
         path.map_or(Some(self.clone()), |p| self.find_directory(&Path(p)))
-            .and_then(|dir| dir.file_in_directory(&filename))
+            .and_then(|dir| dir.file_in_directory(&name))
     }
 
     /// Find a `Directory` in the directory given the `Path` to
@@ -631,7 +631,7 @@ impl Directory {
     /// the `Directory`.
     pub fn find_directory(&self, path: &Path) -> Option<Self> {
         let (label, labels) = path.split_first();
-        if *label == self.label {
+        if *label == self.name {
             // recursively dig down into sub-directories
             labels
                 .iter()
@@ -678,7 +678,7 @@ impl Directory {
         self.sub_directories()
             .iter()
             .cloned()
-            .find(|directory| directory.label == *label)
+            .find(|directory| directory.name == *label)
     }
 
     /// Get the a sub directory of a `Directory` given its name.
@@ -687,7 +687,7 @@ impl Directory {
     fn sub_directory_mut(&mut self, label: &Label) -> Option<&mut Self> {
         self.sub_directories_mut()
             .into_iter()
-            .find(|directory| directory.label == *label)
+            .find(|directory| directory.name == *label)
     }
 
     /// Get the `File` in the current `Directory` if it exists in
@@ -697,7 +697,7 @@ impl Directory {
     fn file_in_directory(&self, label: &Label) -> Option<File> {
         for entry in self.entries.iter() {
             match entry {
-                DirectoryContents::File(file) if file.filename == *label => {
+                DirectoryContents::File(file) if file.name == *label => {
                     return Some(file.clone());
                 }
                 DirectoryContents::File(..) => {}
@@ -709,9 +709,9 @@ impl Directory {
     }
 
     /// Helper function for creating a `Directory` with a given sub-directory.
-    pub(crate) fn mkdir(label: Label, dir: Self) -> Self {
+    pub(crate) fn mkdir(name: Label, dir: Self) -> Self {
         Directory {
-            label,
+            name,
             entries: NonEmpty::new(DirectoryContents::sub_directory(dir)),
         }
     }
@@ -735,7 +735,7 @@ impl Directory {
                 let (prefix, current) = dir.split_last();
 
                 let mut directory = Directory {
-                    label: current,
+                    name: current,
                     entries: file_entries,
                 };
                 for label in prefix.into_iter().rev() {
@@ -749,7 +749,7 @@ impl Directory {
     }
 
     fn combine(&mut self, other: &Directory) {
-        match self.sub_directory_mut(&other.label) {
+        match self.sub_directory_mut(&other.name) {
             Some(ref mut subdir) => {
                 for entry in other.entries.iter() {
                     match entry {
@@ -797,7 +797,7 @@ pub mod tests {
         let file = File::new("foo.hs".into(), b"module Banana ...");
 
         let directory: Directory = Directory {
-            label: Label::root(),
+            name: Label::root(),
             entries: NonEmpty::new(DirectoryContents::File(file.clone())),
         };
 
@@ -816,7 +816,7 @@ pub mod tests {
             Directory::mkdir(
                 "foo".into(),
                 Directory {
-                    label: "bar".into(),
+                    name: "bar".into(),
                     entries: NonEmpty::new(DirectoryContents::File(file.clone())),
                 },
             ),
@@ -831,7 +831,7 @@ pub mod tests {
         let file_path = Path::with_root(&["bar.hs".into()]);
 
         let directory: Directory = Directory {
-            label: Label::root(),
+            name: Label::root(),
             entries: NonEmpty::new(DirectoryContents::file(
                 "foo.hs".into(),
                 "module Banana ...".as_bytes(),
@@ -849,7 +849,7 @@ pub mod tests {
         let baz = DirectoryContents::file("baz.hs".into(), "module Banana ...".as_bytes());
 
         let directory: Directory = Directory {
-            label: Label::root(),
+            name: Label::root(),
             entries: (foo, vec![bar, baz]).into(),
         };
 
@@ -946,7 +946,7 @@ pub mod tests {
     fn file_strategy() -> impl Strategy<Value = File> {
         // ASCII regex, see: https://catonmat.net/my-favorite-regex
         (label_strategy(), "[ -~]*")
-            .prop_map(|(filename, contents)| File::new(filename, contents.as_bytes()))
+            .prop_map(|(name, contents)| File::new(name, contents.as_bytes()))
     }
 
     fn directory_map_strategy(
@@ -989,7 +989,7 @@ pub mod tests {
                     return false;
                 }
 
-                path.push(file.filename.clone());
+                path.push(file.name.clone());
                 if !directory.find_file(&path).is_some() {
                     return false;
                 }
@@ -1037,7 +1037,7 @@ pub mod tests {
             Directory::mkdir(
                 "bar".into(),
                 Directory {
-                    label: "baz".into(),
+                    name: "baz".into(),
                     entries: NonEmpty::new(DirectoryContents::file("quux.rs".into(), b"")),
                 },
             ),
@@ -1049,7 +1049,7 @@ pub mod tests {
             Directory::mkdir(
                 "bar".into(),
                 Directory {
-                    label: "quux".into(),
+                    name: "quux".into(),
                     entries: NonEmpty::new(DirectoryContents::file("hallo.rs".into(), b"")),
                 },
             ),
@@ -1057,11 +1057,11 @@ pub mod tests {
 
         let mut expected_root = Directory::empty_root::<TestRepo>();
         let expected_quux = DirectoryContents::sub_directory(Directory {
-            label: "baz".into(),
+            name: "baz".into(),
             entries: NonEmpty::new(DirectoryContents::file("quux.rs".into(), b"")),
         });
         let expected_hallo = DirectoryContents::sub_directory(Directory {
-            label: "quux".into(),
+            name: "quux".into(),
             entries: NonEmpty::new(DirectoryContents::file("hallo.rs".into(), b"")),
         });
 
@@ -1070,7 +1070,7 @@ pub mod tests {
         let expected = Directory::mkdir(
             "foo".into(),
             Directory {
-                label: "bar".into(),
+                name: "bar".into(),
                 entries: subdirs,
             },
         );
@@ -1103,7 +1103,7 @@ pub mod tests {
         let baz = Directory::mkdir(
             "foo".into(),
             Directory {
-                label: "bar".into(),
+                name: "bar".into(),
                 entries: NonEmpty::new(DirectoryContents::file("baz.rs".into(), b"")),
             },
         );
@@ -1112,7 +1112,7 @@ pub mod tests {
         let quux = Directory::mkdir(
             "foo".into(),
             Directory {
-                label: "bar".into(),
+                name: "bar".into(),
                 entries: NonEmpty::new(DirectoryContents::file("quux.rs".into(), b"")),
             },
         );
@@ -1126,7 +1126,7 @@ pub mod tests {
         let expected = Directory::mkdir(
             "foo".into(),
             Directory {
-                label: "bar".into(),
+                name: "bar".into(),
                 entries: files,
             },
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 //! assert_eq!(root_contents, vec![
 //!     SystemType::directory(".buildkite".into()),
 //!     SystemType::directory(".docker".into()),
-//!     SystemType::directory(".git".into()),
 //!     SystemType::file(".gitignore".into()),
 //!     SystemType::file(".gitmodules".into()),
 //!     SystemType::file("Cargo.toml".into()),

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -604,9 +604,9 @@ impl<'repo> GitBrowser<'repo> {
                 .to_object(repo)
                 .map(|object| {
                     object.as_blob().and_then(|blob| {
-                        entry.name().and_then(|filename| {
+                        entry.name().and_then(|name| {
                             let file = file_system::File {
-                                filename: filename.into(),
+                                name: name.into(),
                                 contents: blob.content().to_owned(),
                                 size: blob.size(),
                             };
@@ -629,11 +629,11 @@ impl<'repo> GitBrowser<'repo> {
         commit: Commit<'repo>,
         path: &file_system::Path,
     ) -> Option<Commit<'repo>> {
-        let (directory, filename) = path.split_last();
+        let (directory, name) = path.split_last();
         let commit_tree = commit.tree().ok()?;
 
         if directory == vec![file_system::Label::root()] {
-            commit_tree.get_name(&filename.0).map(|_| commit)
+            commit_tree.get_name(&name.label).map(|_| commit)
         } else {
             let mut directory_path = std::path::PathBuf::new();
             for dir in directory {
@@ -641,12 +641,12 @@ impl<'repo> GitBrowser<'repo> {
                     continue;
                 }
 
-                directory_path.push(dir.0);
+                directory_path.push(dir.label);
             }
 
             let tree_entry = commit_tree.get_path(directory_path.as_path()).ok()?;
             let object = tree_entry.to_object(&self.repository.0).ok()?;
-            let tree = object.as_tree().map(|t| t.get_name(&filename.0));
+            let tree = object.as_tree().map(|t| t.get_name(&name.label));
             tree.map(|_| commit)
         }
     }

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -12,7 +12,6 @@
 //! directory_contents.sort();
 //!
 //! assert_eq!(directory_contents, vec![
-//!     SystemType::directory(".git".into()),
 //!     SystemType::file(".gitignore".into()),
 //!     SystemType::file("Cargo.toml".into()),
 //!     SystemType::directory("src".into()),
@@ -255,7 +254,10 @@ impl<'repo> vcs::VCS<'repo, Commit<'repo>, GitError> for GitRepository {
 impl file_system::RepoBackend for GitRepository {
     fn repo_directory() -> file_system::Directory {
         file_system::Directory {
-            label: ".git".into(),
+            name: file_system::Label {
+                label: ".git".into(),
+                hidden: true,
+            },
             entries: NonEmpty::new(file_system::DirectoryContents::Repo),
         }
     }
@@ -356,7 +358,6 @@ impl<'repo> GitBrowser<'repo> {
     /// assert_eq!(
     ///     directory_contents,
     ///     vec![
-    ///         SystemType::directory(".git".into()),
     ///         SystemType::file(".gitignore".into()),
     ///         SystemType::file("Cargo.toml".into()),
     ///         SystemType::directory("src".into()),
@@ -440,11 +441,10 @@ impl<'repo> GitBrowser<'repo> {
     /// let mut directory_contents = directory.list_directory();
     /// directory_contents.sort();
     ///
-    /// // We should only have src and .git in our root
+    /// // We should only have src in our root
     /// assert_eq!(
     ///     directory_contents,
     ///     vec![
-    ///         SystemType::directory(".git".into()),
     ///         SystemType::directory("src".into()),
     ///     ]
     /// );


### PR DESCRIPTION
Fixes #28 

* Adds a protected field to `Label` called `hidden`. We use this for the special git repos.
* Rename `File`'s `filename` to `name`
* Rename `Directory`'s `label` to `name`

The last two were for readability and DRY'ing up naming