### PR TITLE
Passing root Path to last_commit produces None

### DIFF
--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -630,6 +630,22 @@ impl<'repo> GitBrowser<'repo> {
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(main_last_commit, Some(head_commit.id()));
+    ///
+    /// // Query for root directory shows proper commit.
+    ///
+    /// let root_last_commit = browser
+    ///     .last_commit(&Path::root())
+    ///     .map(|commit| commit.id());
+    ///
+    /// assert_eq!(root_last_commit, Some(head_commit.id()));
+    ///
+    /// // Query for src directory shows proper commit.
+    ///
+    /// let src_last_commit = browser
+    ///     .last_commit(&Path::with_root(&["src".into()]))
+    ///     .map(|commit| commit.id());
+    ///
+    /// assert_eq!(src_last_commit, Some(head_commit.id()));
     /// ```
     pub fn last_commit(&self, path: &file_system::Path) -> Option<Commit> {
         self.get_history()


### PR DESCRIPTION
This is a POC to show that when passing `Path::root()` to `last_commit` it results in `None`. It caused trouble for us when querying for the last commit of a tree that happen to be the repository root or in our terms an `""` prefix. I open this to pose the question if this is intended behaviour and if it's the callers responsibility to guard against that case.