### PR TITLE
Checking is_root on a Path created with empty string is false

### DIFF
--- a/src/file_system/mod.rs
+++ b/src/file_system/mod.rs
@@ -111,9 +111,11 @@ impl Path {
     ///
     /// let root = Path::root();
     /// let not_root = Path::with_root(&["src".into(), "lib.rs".into()]);
+    /// let empty = Path::with_root(&["".into()]);
     ///
     /// assert!(root.is_root());
     /// assert!(!not_root.is_root());
+    /// assert!(empty.is_root());
     /// ```
     pub fn is_root(&self) -> bool {
         *self == Self::root()


### PR DESCRIPTION
This is a POC with the help of a doc test showing when checking for `is_root` on a `Path::with_root(&["".into()])` is `false`. Is this intended behaviour? How should a caller should treat this case correctly?