### PR TITLE
Relative Directory Ops

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! let directory = browser.get_directory().unwrap();
 //!
 //! // Let's get a Path to this file
-//! let this_file = Path::with_root(&["src".into(), "lib.rs".into()]);
+//! let this_file = Path::from_labels("src".into(), &["lib.rs".into()]);
 //!
 //! // And assert that we can find it!
 //! assert!(directory.find_file(&this_file).is_some());
@@ -47,7 +47,7 @@
 //!     SystemType::directory("src".into()),
 //! ]);
 //!
-//! let src = directory.find_directory(&Path::with_root(&["src".into()])).unwrap();
+//! let src = directory.find_directory(&Path::new("src".into())).unwrap();
 //! let mut src_contents = src.list_directory();
 //! src_contents.sort();
 //!

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -23,7 +23,7 @@
 //!
 //! // find src directory in the Git directory and the in-memory directory
 //! let src_directory = directory
-//!     .find_directory(&Path::with_root(&["src".into()]))
+//!     .find_directory(&Path::new("src".into()))
 //!     .unwrap();
 //! let mut src_directory_contents = src_directory.list_directory();
 //! src_directory_contents.sort();
@@ -421,7 +421,7 @@ impl<'repo> GitBrowser<'repo> {
     /// );
     ///
     /// let tests = directory
-    ///     .find_directory(&Path::with_root(&["bin".into()]))
+    ///     .find_directory(&Path::new("bin".into()))
     ///     .expect("bin not found");
     /// let mut tests_contents = tests.list_directory();
     /// tests_contents.sort();


### PR DESCRIPTION
* Makes operation relative to the `Directory` the caller is in
* Should remove the use of `root` but will keep it in for backward-compat for now