### PR TITLE
Fintan/label conversion

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -309,7 +309,7 @@ mod tests {
     impl RepoBackend for TestRepo {
         fn repo_directory() -> Directory {
             Directory {
-                name: ".test".into(),
+                name: unsound::label::new(".test"),
                 entries: NonEmpty::new(DirectoryContents::Repo),
             }
         }
@@ -326,14 +326,19 @@ mod tests {
             name: Label::root(),
             entries: (
                 DirectoryContents::Repo,
-                vec![DirectoryContents::file("banana.rs".into(), b"use banana")],
+                vec![DirectoryContents::file(
+                    unsound::label::new("banana.rs"),
+                    b"use banana",
+                )],
             )
                 .into(),
         };
 
         let diff = Diff::diff(directory, new_directory).expect("diff failed");
         let expected_diff = Diff {
-            created: vec![CreateFile(Path::with_root(&["banana.rs".into()]))],
+            created: vec![CreateFile(Path::with_root(&[unsound::label::new(
+                "banana.rs",
+            )]))],
             deleted: vec![],
             moved: vec![],
             modified: vec![],
@@ -348,7 +353,10 @@ mod tests {
             name: Label::root(),
             entries: (
                 DirectoryContents::Repo,
-                vec![DirectoryContents::file("banana.rs".into(), b"use banana")],
+                vec![DirectoryContents::file(
+                    unsound::label::new("banana.rs"),
+                    b"use banana",
+                )],
             )
                 .into(),
         };
@@ -361,7 +369,9 @@ mod tests {
         let diff = Diff::diff(directory, new_directory).expect("diff failed");
         let expected_diff = Diff {
             created: vec![],
-            deleted: vec![DeleteFile(Path::with_root(&["banana.rs".into()]))],
+            deleted: vec![DeleteFile(Path::with_root(&[unsound::label::new(
+                "banana.rs",
+            )]))],
             moved: vec![],
             modified: vec![],
         };
@@ -373,12 +383,18 @@ mod tests {
     fn test_moved_file() {
         let directory: Directory = Directory {
             name: Label::root(),
-            entries: NonEmpty::new(DirectoryContents::file("mod.rs".into(), b"use banana")),
+            entries: NonEmpty::new(DirectoryContents::file(
+                unsound::label::new("mod.rs"),
+                b"use banana",
+            )),
         };
 
         let new_directory: Directory = Directory {
             name: Label::root(),
-            entries: NonEmpty::new(DirectoryContents::file("banana.rs".into(), b"use banana")),
+            entries: NonEmpty::new(DirectoryContents::file(
+                unsound::label::new("banana.rs"),
+                b"use banana",
+            )),
         };
 
         let diff = Diff::diff(directory, new_directory).expect("diff failed");
@@ -394,7 +410,10 @@ mod tests {
             name: Label::root(),
             entries: (
                 DirectoryContents::Repo,
-                vec![DirectoryContents::file("banana.rs".into(), b"use banana")],
+                vec![DirectoryContents::file(
+                    unsound::label::new("banana.rs"),
+                    b"use banana",
+                )],
             )
                 .into(),
         };
@@ -403,7 +422,10 @@ mod tests {
             name: Label::root(),
             entries: (
                 DirectoryContents::Repo,
-                vec![DirectoryContents::file("banana.rs".into(), b"use banana;")],
+                vec![DirectoryContents::file(
+                    unsound::label::new("banana.rs"),
+                    b"use banana;",
+                )],
             )
                 .into(),
         };
@@ -414,7 +436,7 @@ mod tests {
             deleted: vec![],
             moved: vec![],
             modified: vec![ModifiedFile {
-                path: Path::with_root(&["banana.rs".into()]),
+                path: Path::with_root(&[unsound::label::new("banana.rs")]),
                 diff: FileDiff {},
             }],
         };
@@ -434,9 +456,9 @@ mod tests {
             entries: (
                 DirectoryContents::Repo,
                 vec![DirectoryContents::sub_directory(Directory {
-                    name: "src".into(),
+                    name: unsound::label::new("src"),
                     entries: NonEmpty::new(DirectoryContents::file(
-                        "banana.rs".into(),
+                        unsound::label::new("banana.rs"),
                         b"use banana",
                     )),
                 })],
@@ -447,8 +469,8 @@ mod tests {
         let diff = Diff::diff(directory, new_directory).expect("diff failed");
         let expected_diff = Diff {
             created: vec![CreateFile(Path::with_root(&[
-                "src".into(),
-                "banana.rs".into(),
+                unsound::label::new("src"),
+                unsound::label::new("banana.rs"),
             ]))],
             deleted: vec![],
             moved: vec![],
@@ -465,9 +487,9 @@ mod tests {
             entries: (
                 DirectoryContents::Repo,
                 vec![DirectoryContents::sub_directory(Directory {
-                    name: "src".into(),
+                    name: unsound::label::new("src"),
                     entries: NonEmpty::new(DirectoryContents::file(
-                        "banana.rs".into(),
+                        unsound::label::new("banana.rs"),
                         b"use banana",
                     )),
                 })],
@@ -484,8 +506,8 @@ mod tests {
         let expected_diff = Diff {
             created: vec![],
             deleted: vec![DeleteFile(Path::with_root(&[
-                "src".into(),
-                "banana.rs".into(),
+                unsound::label::new("src"),
+                unsound::label::new("banana.rs"),
             ]))],
             moved: vec![],
             modified: vec![],
@@ -501,9 +523,9 @@ mod tests {
             entries: (
                 DirectoryContents::Repo,
                 vec![DirectoryContents::sub_directory(Directory {
-                    name: "src".into(),
+                    name: unsound::label::new("src"),
                     entries: NonEmpty::new(DirectoryContents::file(
-                        "banana.rs".into(),
+                        unsound::label::new("banana.rs"),
                         b"use banana",
                     )),
                 })],
@@ -516,9 +538,9 @@ mod tests {
             entries: (
                 DirectoryContents::Repo,
                 vec![DirectoryContents::sub_directory(Directory {
-                    name: "src".into(),
+                    name: unsound::label::new("src"),
                     entries: NonEmpty::new(DirectoryContents::file(
-                        "banana.rs".into(),
+                        unsound::label::new("banana.rs"),
                         b"use banana;",
                     )),
                 })],
@@ -532,7 +554,10 @@ mod tests {
             deleted: vec![],
             moved: vec![],
             modified: vec![ModifiedFile {
-                path: Path::with_root(&["src".into(), "banana.rs".into()]),
+                path: Path::with_root(&[
+                    unsound::label::new("src"),
+                    unsound::label::new("banana.rs"),
+                ]),
                 diff: FileDiff {},
             }],
         };
@@ -543,19 +568,22 @@ mod tests {
     #[test]
     fn test_disjoint_directories() {
         let directory: Directory = Directory {
-            name: "foo".into(),
+            name: unsound::label::new("foo"),
             entries: NonEmpty::new(DirectoryContents::sub_directory(Directory {
-                name: "src".into(),
-                entries: NonEmpty::new(DirectoryContents::file("banana.rs".into(), b"use banana")),
+                name: unsound::label::new("src"),
+                entries: NonEmpty::new(DirectoryContents::file(
+                    unsound::label::new("banana.rs"),
+                    b"use banana",
+                )),
             })),
         };
 
         let other_directory: Directory = Directory {
-            name: "bar".into(),
+            name: unsound::label::new("bar"),
             entries: NonEmpty::new(DirectoryContents::sub_directory(Directory {
-                name: "src".into(),
+                name: unsound::label::new("src"),
                 entries: NonEmpty::new(DirectoryContents::file(
-                    "pineapple.rs".into(),
+                    unsound::label::new("pineapple.rs"),
                     b"use pineapple",
                 )),
             })),
@@ -564,12 +592,15 @@ mod tests {
         let diff = Diff::diff(directory, other_directory).expect("diff failed");
         let expected_diff = Diff {
             created: vec![CreateFile(Path::from_labels(
-                "bar".into(),
-                &["src".into(), "pineapple.rs".into()],
+                unsound::label::new("bar"),
+                &[
+                    unsound::label::new("src"),
+                    unsound::label::new("pineapple.rs"),
+                ],
             ))],
             deleted: vec![DeleteFile(Path::from_labels(
-                "foo".into(),
-                &["src".into(), "banana.rs".into()],
+                unsound::label::new("foo"),
+                &[unsound::label::new("src"), unsound::label::new("banana.rs")],
             ))],
             moved: vec![],
             modified: vec![],

--- a/src/file_system/error.rs
+++ b/src/file_system/error.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    Label(Label),
+    Path(Path),
+}
+
+impl From<Label> for Error {
+    fn from(err: Label) -> Self {
+        Error::Label(err)
+    }
+}
+
+impl From<Path> for Error {
+    fn from(err: Path) -> Self {
+        Error::Path(err)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Path {
+    Empty,
+    Label(Label),
+}
+
+impl From<Label> for Path {
+    fn from(err: Label) -> Self {
+        Path::Label(err)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Label {
+    ContainsSlash,
+    Empty,
+}

--- a/src/file_system/error.rs
+++ b/src/file_system/error.rs
@@ -1,3 +1,7 @@
+pub(crate) const EMPTY_PATH: Error = Error::Path(Path::Empty);
+pub(crate) const EMPTY_LABEL: Error = Error::Label(Label::Empty);
+pub(crate) const CONTAINS_SLASH: Error = Error::Label(Label::ContainsSlash);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     Label(Label),
@@ -19,13 +23,6 @@ impl From<Path> for Error {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Path {
     Empty,
-    Label(Label),
-}
-
-impl From<Label> for Path {
-    fn from(err: Label) -> Self {
-        Path::Label(err)
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/file_system/mod.rs
+++ b/src/file_system/mod.rs
@@ -23,7 +23,7 @@ pub mod unsound;
 /// use radicle_surf::file_system::{Label, Path};
 /// use std::convert::TryFrom;
 ///
-/// fn build_lib_path() -> Result<Path, file_error::Label> {
+/// fn build_lib_path() -> Result<Path, file_error::Error> {
 ///     let lib_filename = Label::try_from("lib.rs")?;
 ///     let src_directory_name = Label::try_from("src")?;
 ///     Ok(Path::from_labels(src_directory_name, &[lib_filename]))

--- a/src/file_system/mod.rs
+++ b/src/file_system/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::str::FromStr;
 
 pub mod error;
 pub use crate::file_system::error as file_error;
@@ -83,6 +84,14 @@ impl TryFrom<&str> for Label {
     }
 }
 
+impl FromStr for Label {
+    type Err = file_error::Label;
+
+    fn from_str(item: &str) -> Result<Self, Self::Err> {
+        Label::try_from(item)
+    }
+}
+
 /// A non-empty set of [`Label`](struct.Label.html)s to define a path
 /// in a directory or file search.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -112,6 +121,14 @@ impl TryFrom<&str> for Path {
         NonEmpty::from_slice(&path)
             .ok_or(file_error::Path::Empty)
             .map(Path)
+    }
+}
+
+impl FromStr for Path {
+    type Err = file_error::Path;
+
+    fn from_str(item: &str) -> Result<Self, Self::Err> {
+        Path::try_from(item)
     }
 }
 

--- a/src/file_system/mod.rs
+++ b/src/file_system/mod.rs
@@ -68,13 +68,13 @@ impl fmt::Display for Label {
 }
 
 impl TryFrom<&str> for Label {
-    type Error = file_error::Label;
+    type Error = file_error::Error;
 
     fn try_from(item: &str) -> Result<Self, Self::Error> {
         if item.is_empty() {
-            Err(file_error::Label::Empty)
+            Err(file_error::EMPTY_LABEL)
         } else if item.contains('/') {
-            Err(file_error::Label::ContainsSlash)
+            Err(file_error::CONTAINS_SLASH)
         } else {
             Ok(Label {
                 label: item.into(),
@@ -85,7 +85,7 @@ impl TryFrom<&str> for Label {
 }
 
 impl FromStr for Label {
-    type Err = file_error::Label;
+    type Err = file_error::Error;
 
     fn from_str(item: &str) -> Result<Self, Self::Err> {
         Label::try_from(item)
@@ -108,7 +108,7 @@ impl fmt::Display for Path {
 }
 
 impl TryFrom<&str> for Path {
-    type Error = file_error::Path;
+    type Error = file_error::Error;
 
     fn try_from(item: &str) -> Result<Self, Self::Error> {
         let mut path = Vec::new();
@@ -119,13 +119,13 @@ impl TryFrom<&str> for Path {
         }
 
         NonEmpty::from_slice(&path)
-            .ok_or(file_error::Path::Empty)
+            .ok_or(file_error::EMPTY_PATH)
             .map(Path)
     }
 }
 
 impl FromStr for Path {
-    type Err = file_error::Path;
+    type Err = file_error::Error;
 
     fn from_str(item: &str) -> Result<Self, Self::Err> {
         Path::try_from(item)

--- a/src/file_system/unsound.rs
+++ b/src/file_system/unsound.rs
@@ -1,0 +1,27 @@
+pub mod path {
+    use crate::file_system::Path;
+    use std::convert::TryFrom;
+
+    /// **NB**: Use with caution!
+    ///
+    /// Calls `try_from` on the input and expects it to not fail.
+    ///
+    /// Used for testing and playground purposes.
+    pub fn new(path: &str) -> Path {
+        Path::try_from(path).expect("unsafe_path: Failed to parse path")
+    }
+}
+
+pub mod label {
+    use crate::file_system::Label;
+    use std::convert::TryFrom;
+
+    /// **NB**: Use with caution!
+    ///
+    /// Calls `try_from` on the input and expects it to not fail.
+    ///
+    /// Used for testing and playground purposes.
+    pub fn new(path: &str) -> Label {
+        Label::try_from(path).expect("unsafe_path: Failed to parse label")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 //! ```
 //! use radicle_surf::vcs::git::{GitBrowser, GitRepository, Sha1};
 //! use radicle_surf::file_system::{Label, Path, SystemType};
+//! use radicle_surf::file_system::unsound;
 //! use pretty_assertions::assert_eq;
 //!
 //! // We're going to point to this repo.
@@ -27,7 +28,7 @@
 //! let directory = browser.get_directory().expect("Failed to get directory");
 //!
 //! // Let's get a Path to this file
-//! let this_file = Path::from_labels(Label::unsafe_label("src"), &[Label::unsafe_label("memory.rs")]);
+//! let this_file = Path::from_labels(unsound::label::new("src"), &[unsound::label::new("memory.rs")]);
 //!
 //! // And assert that we can find it!
 //! assert!(directory.find_file(&this_file).is_some());
@@ -36,26 +37,26 @@
 //! root_contents.sort();
 //!
 //! assert_eq!(root_contents, vec![
-//!     SystemType::file(Label::unsafe_label(".i-am-well-hidden")),
-//!     SystemType::file(Label::unsafe_label(".i-too-am-hidden")),
-//!     SystemType::file(Label::unsafe_label("README.md")),
-//!     SystemType::directory(Label::unsafe_label("bin")),
-//!     SystemType::directory(Label::unsafe_label("src")),
-//!     SystemType::directory(Label::unsafe_label("text")),
-//!     SystemType::directory(Label::unsafe_label("this")),
+//!     SystemType::file(unsound::label::new(".i-am-well-hidden")),
+//!     SystemType::file(unsound::label::new(".i-too-am-hidden")),
+//!     SystemType::file(unsound::label::new("README.md")),
+//!     SystemType::directory(unsound::label::new("bin")),
+//!     SystemType::directory(unsound::label::new("src")),
+//!     SystemType::directory(unsound::label::new("text")),
+//!     SystemType::directory(unsound::label::new("this")),
 //! ]);
 //!
 //! let src = directory.find_directory(
-//!     &Path::new(Label::unsafe_label("src"))
+//!     &Path::new(unsound::label::new("src"))
 //! ).expect("Failed to find src");
 //!
 //! let mut src_contents = src.list_directory();
 //! src_contents.sort();
 //!
 //! assert_eq!(src_contents, vec![
-//!     SystemType::file(Label::unsafe_label("Eval.hs")),
-//!     SystemType::file(Label::unsafe_label("Folder.svelte")),
-//!     SystemType::file(Label::unsafe_label("memory.rs")),
+//!     SystemType::file(unsound::label::new("Eval.hs")),
+//!     SystemType::file(unsound::label::new("Folder.svelte")),
+//!     SystemType::file(unsound::label::new("memory.rs")),
 //! ]);
 //! ```
 pub mod diff;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,21 +13,21 @@
 //! use pretty_assertions::assert_eq;
 //!
 //! // We're going to point to this repo.
-//! let repo = GitRepository::new(".").unwrap();
+//! let repo = GitRepository::new("./data/git-platinum").expect("Failed to initialise repo");
 //!
 //! // Here we initialise a new Broswer for a the git repo.
-//! let mut browser = GitBrowser::new(&repo).unwrap();
+//! let mut browser = GitBrowser::new(&repo).expect("Failed to initialise browser");
 //!
 //! // Set the history to a particular commit
-//! browser.commit(Sha1::new("840e75edc46c84b6392b3f38e1d830547fac89a4"))
+//! browser.commit(Sha1::new("80ded66281a4de2889cc07293a8f10947c6d57fe"))
 //!        .expect("Failed to set commit");
 //!
 //! // Get the snapshot of the directory for our current
 //! // HEAD of history.
-//! let directory = browser.get_directory().unwrap();
+//! let directory = browser.get_directory().expect("Failed to get directory");
 //!
 //! // Let's get a Path to this file
-//! let this_file = Path::from_labels("src".into(), &["lib.rs".into()]);
+//! let this_file = Path::from_labels(Label::unsafe_label("src"), &[Label::unsafe_label("memory.rs")]);
 //!
 //! // And assert that we can find it!
 //! assert!(directory.find_file(&this_file).is_some());
@@ -36,26 +36,26 @@
 //! root_contents.sort();
 //!
 //! assert_eq!(root_contents, vec![
-//!     SystemType::directory(".buildkite".into()),
-//!     SystemType::directory(".docker".into()),
-//!     SystemType::file(".gitignore".into()),
-//!     SystemType::file(".gitmodules".into()),
-//!     SystemType::file("Cargo.toml".into()),
-//!     SystemType::file("README.md".into()),
-//!     SystemType::directory("docs".into()),
-//!     SystemType::directory("examples".into()),
-//!     SystemType::directory("src".into()),
+//!     SystemType::file(Label::unsafe_label(".i-am-well-hidden")),
+//!     SystemType::file(Label::unsafe_label(".i-too-am-hidden")),
+//!     SystemType::file(Label::unsafe_label("README.md")),
+//!     SystemType::directory(Label::unsafe_label("bin")),
+//!     SystemType::directory(Label::unsafe_label("src")),
+//!     SystemType::directory(Label::unsafe_label("text")),
+//!     SystemType::directory(Label::unsafe_label("this")),
 //! ]);
 //!
-//! let src = directory.find_directory(&Path::new("src".into())).unwrap();
+//! let src = directory.find_directory(
+//!     &Path::new(Label::unsafe_label("src"))
+//! ).expect("Failed to find src");
+//!
 //! let mut src_contents = src.list_directory();
 //! src_contents.sort();
 //!
 //! assert_eq!(src_contents, vec![
-//!     SystemType::directory("diff".into()),
-//!     SystemType::directory("file_system".into()),
-//!     SystemType::file("lib.rs".into()),
-//!     SystemType::directory("vcs".into()),
+//!     SystemType::file(Label::unsafe_label("Eval.hs")),
+//!     SystemType::file(Label::unsafe_label("Folder.svelte")),
+//!     SystemType::file(Label::unsafe_label("memory.rs")),
 //! ]);
 //! ```
 pub mod diff;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! let directory = browser.get_directory().unwrap();
 //!
 //! // Let's get a Path to this file
-//! let this_file = Path::with_root(&["src".into(), "lib.rs".into()]);
+//! let this_file = Path::from_labels("src".into(), &["lib.rs".into()]);
 //!
 //! // And assert that we can find it!
 //! assert!(directory.find_file(&this_file).is_some());
@@ -47,7 +47,7 @@
 //!     SystemType::directory("src".into()),
 //! ]);
 //!
-//! let src = directory.find_directory(&Path::with_root(&["src".into()])).unwrap();
+//! let src = directory.find_directory(&Path::new("src".into())).unwrap();
 //! let mut src_contents = src.list_directory();
 //! src_contents.sort();
 //!

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -1,6 +1,7 @@
 //! ```
 //! use nonempty::NonEmpty;
-//! use radicle_surf::file_system::{Directory, File, Path, SystemType};
+//! use radicle_surf::file_system::{Directory, File, Label, Path, SystemType};
+//! use radicle_surf::file_system::unsound;
 //! use radicle_surf::vcs::git::*;
 //! use std::collections::HashMap;
 //!
@@ -12,26 +13,26 @@
 //! directory_contents.sort();
 //!
 //! assert_eq!(directory_contents, vec![
-//!     SystemType::file(".i-am-well-hidden".into()),
-//!     SystemType::file(".i-too-am-hidden".into()),
-//!     SystemType::file("README.md".into()),
-//!     SystemType::directory("bin".into()),
-//!     SystemType::directory("src".into()),
-//!     SystemType::directory("text".into()),
-//!     SystemType::directory("this".into()),
+//!     SystemType::file(unsound::label::new(".i-am-well-hidden")),
+//!     SystemType::file(unsound::label::new(".i-too-am-hidden")),
+//!     SystemType::file(unsound::label::new("README.md")),
+//!     SystemType::directory(unsound::label::new("bin")),
+//!     SystemType::directory(unsound::label::new("src")),
+//!     SystemType::directory(unsound::label::new("text")),
+//!     SystemType::directory(unsound::label::new("this")),
 //! ]);
 //!
 //! // find src directory in the Git directory and the in-memory directory
 //! let src_directory = directory
-//!     .find_directory(&Path::new("src".into()))
+//!     .find_directory(&Path::new(unsound::label::new("src")))
 //!     .unwrap();
 //! let mut src_directory_contents = src_directory.list_directory();
 //! src_directory_contents.sort();
 //!
 //! assert_eq!(src_directory_contents, vec![
-//!     SystemType::file("Eval.hs".into()),
-//!     SystemType::file("Folder.svelte".into()),
-//!     SystemType::file("memory.rs".into()),
+//!     SystemType::file(unsound::label::new("Eval.hs")),
+//!     SystemType::file(unsound::label::new("Folder.svelte")),
+//!     SystemType::file(unsound::label::new("memory.rs")),
 //! ]);
 //! ```
 
@@ -395,6 +396,7 @@ impl<'repo> GitBrowser<'repo> {
     /// ```
     /// use radicle_surf::vcs::git::{BranchName, GitBrowser, GitRepository};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
+    /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = GitRepository::new("./data/git-platinum").unwrap();
     /// let mut browser = GitBrowser::new(&repo).unwrap();
@@ -409,19 +411,19 @@ impl<'repo> GitBrowser<'repo> {
     /// assert_eq!(
     ///     directory_contents,
     ///     vec![
-    ///         SystemType::file(".i-am-well-hidden".into()),
-    ///         SystemType::file(".i-too-am-hidden".into()),
-    ///         SystemType::file("README.md".into()),
-    ///         SystemType::directory("bin".into()),
-    ///         SystemType::file("here-we-are-on-a-dev-branch.lol".into()),
-    ///         SystemType::directory("src".into()),
-    ///         SystemType::directory("text".into()),
-    ///         SystemType::directory("this".into()),
+    ///         SystemType::file(unsound::label::new(".i-am-well-hidden")),
+    ///         SystemType::file(unsound::label::new(".i-too-am-hidden")),
+    ///         SystemType::file(unsound::label::new("README.md")),
+    ///         SystemType::directory(unsound::label::new("bin")),
+    ///         SystemType::file(unsound::label::new("here-we-are-on-a-dev-branch.lol")),
+    ///         SystemType::directory(unsound::label::new("src")),
+    ///         SystemType::directory(unsound::label::new("text")),
+    ///         SystemType::directory(unsound::label::new("this")),
     ///     ]
     /// );
     ///
     /// let tests = directory
-    ///     .find_directory(&Path::new("bin".into()))
+    ///     .find_directory(&Path::new(unsound::label::new("bin")))
     ///     .expect("bin not found");
     /// let mut tests_contents = tests.list_directory();
     /// tests_contents.sort();
@@ -429,9 +431,9 @@ impl<'repo> GitBrowser<'repo> {
     /// assert_eq!(
     ///     tests_contents,
     ///     vec![
-    ///         SystemType::file("cat".into()),
-    ///         SystemType::file("ls".into()),
-    ///         SystemType::file("test".into()),
+    ///         SystemType::file(unsound::label::new("cat")),
+    ///         SystemType::file(unsound::label::new("ls")),
+    ///         SystemType::file(unsound::label::new("test")),
     ///     ]
     /// );
     /// ```
@@ -485,8 +487,9 @@ impl<'repo> GitBrowser<'repo> {
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::file_system::SystemType;
+    /// use radicle_surf::file_system::{Label, SystemType};
     /// use radicle_surf::vcs::git::{GitBrowser, GitRepository, Sha1};
+    /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = GitRepository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
@@ -505,10 +508,10 @@ impl<'repo> GitBrowser<'repo> {
     /// assert_eq!(
     ///     directory_contents,
     ///     vec![
-    ///         SystemType::file("README.md".into()),
-    ///         SystemType::directory("bin".into()),
-    ///         SystemType::directory("src".into()),
-    ///         SystemType::directory("this".into()),
+    ///         SystemType::file(unsound::label::new("README.md")),
+    ///         SystemType::directory(unsound::label::new("bin")),
+    ///         SystemType::directory(unsound::label::new("src")),
+    ///         SystemType::directory(unsound::label::new("this")),
     ///     ]
     /// );
     ///
@@ -612,6 +615,7 @@ impl<'repo> GitBrowser<'repo> {
     /// ```
     /// use radicle_surf::vcs::git::{GitBrowser, GitRepository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
+    /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = GitRepository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-test as git repository");
@@ -620,13 +624,13 @@ impl<'repo> GitBrowser<'repo> {
     /// let head_commit = browser.get_history().0.first().clone();
     ///
     /// let readme_last_commit = browser
-    ///     .last_commit(&Path::with_root(&["README.md".into()]))
+    ///     .last_commit(&Path::with_root(&[unsound::label::new("README.md")]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(readme_last_commit, Some(head_commit.id()));
     ///
     /// let memory_last_commit = browser
-    ///     .last_commit(&Path::with_root(&["src".into(), "memory.rs".into()]))
+    ///     .last_commit(&Path::with_root(&[unsound::label::new("src"), unsound::label::new("memory.rs")]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(memory_last_commit, Some(head_commit.id()));
@@ -635,6 +639,7 @@ impl<'repo> GitBrowser<'repo> {
     /// ```
     /// use radicle_surf::vcs::git::{GitBrowser, GitRepository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
+    /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = GitRepository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
@@ -647,14 +652,14 @@ impl<'repo> GitBrowser<'repo> {
     ///
     /// // memory.rs is commited later so it should not exist here.
     /// let memory_last_commit = browser
-    ///     .last_commit(&Path::with_root(&["src".into(), "memory.rs".into()]))
+    ///     .last_commit(&Path::with_root(&[unsound::label::new("src"), unsound::label::new("memory.rs")]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(memory_last_commit, None);
     ///
     /// // README.md exists in this commit.
     /// let readme_last_commit = browser
-    ///     .last_commit(&Path::with_root(&["README.md".into()]))
+    ///     .last_commit(&Path::with_root(&[unsound::label::new("README.md")]))
     ///     .map(|commit| commit.id());
     ///
     /// assert_eq!(readme_last_commit, Some(head_commit.id()));

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -356,8 +356,8 @@ impl From<Error> for TreeWalkError {
     }
 }
 
-impl From<file_error::Path> for TreeWalkError {
-    fn from(err: file_error::Path) -> Self {
+impl From<file_error::Error> for TreeWalkError {
+    fn from(err: file_error::Error) -> Self {
         err.into()
     }
 }
@@ -781,9 +781,7 @@ impl<'repo> GitBrowser<'repo> {
         let blob = object.as_blob().ok_or(TreeWalkError::NotBlob)?;
         let name = entry.name().ok_or(GitError::NameDecode)?;
 
-        let name = file_system::Label::try_from(name)
-            .map_err(file_error::Error::Label)
-            .map_err(GitError::FileSystem)?;
+        let name = file_system::Label::try_from(name).map_err(GitError::FileSystem)?;
 
         Ok((
             path,

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -23,7 +23,7 @@
 //!
 //! // find src directory in the Git directory and the in-memory directory
 //! let src_directory = directory
-//!     .find_directory(&Path::with_root(&["src".into()]))
+//!     .find_directory(&Path::new("src".into()))
 //!     .unwrap();
 //! let mut src_directory_contents = src_directory.list_directory();
 //! src_directory_contents.sort();
@@ -421,7 +421,7 @@ impl<'repo> GitBrowser<'repo> {
     /// );
     ///
     /// let tests = directory
-    ///     .find_directory(&Path::with_root(&["bin".into()]))
+    ///     .find_directory(&Path::new("bin".into()))
     ///     .expect("bin not found");
     /// let mut tests_contents = tests.list_directory();
     /// tests_contents.sort();


### PR DESCRIPTION
Fixes #35 

Introduces parsing `str` to get `Label` and `Path`.

* Parsing `str` now return `Result`
* Introduces `unsound` module which is the escape hatch for making `Label`s and `Path`s without handling `Result`s all the time.
* Needed to add new logic in `git` to handle the `Result` from above.
