### PR TITLE
Improve name consistency for public git entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Alongside this, we will wish to take two snapshots and view their differences.
 Let's start surfing (and apologies for the `unwrap`s):
 
 ```rust
-use radicle_surf::vcs::git::{GitBrowser, GitRepository};
+use radicle_surf::vcs::git;
 use radicle_surf::file_system::{Label, Path, SystemType};
 
 // We're going to point to this repo.
-let repo = GitRepository::new(".").unwrap();
+let repo = git::Repository::new(".").unwrap();
 
 // Here we initialise a new Broswer for a the git repo.
-let browser = GitBrowser::new(&repo).unwrap();
+let browser = git::Browser::new(&repo).unwrap();
 
 // Get the snapshot of the directory for our current
 // HEAD of history.

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -8,7 +8,7 @@ use nonempty::NonEmpty;
 
 use radicle_surf::diff::Diff;
 use radicle_surf::file_system::Directory;
-use radicle_surf::vcs::git::{GitBrowser, Repository};
+use radicle_surf::vcs::git;
 use radicle_surf::vcs::History;
 
 fn main() {
@@ -52,8 +52,8 @@ fn get_options_or_exit() -> Options {
     };
 }
 
-fn init_repository_or_exit(path_to_repo: &str) -> Repository {
-    match Repository::new(path_to_repo) {
+fn init_repository_or_exit(path_to_repo: &str) -> git::Repository {
+    match git::Repository::new(path_to_repo) {
         Ok(repo) => return repo,
         Err(e) => {
             println!("Failed to create repository: {:?}", e);
@@ -62,8 +62,8 @@ fn init_repository_or_exit(path_to_repo: &str) -> Repository {
     };
 }
 
-fn init_browser_or_exit(repo: Repository) -> GitBrowser {
-    match GitBrowser::new(repo) {
+fn init_browser_or_exit(repo: git::Repository) -> git::Browser {
+    match git::Browser::new(repo) {
         Ok(browser) => return browser,
         Err(e) => {
             println!("Failed to create browser: {:?}", e);
@@ -72,14 +72,14 @@ fn init_browser_or_exit(repo: Repository) -> GitBrowser {
     };
 }
 
-fn reset_browser_to_head_or_exit(browser: &mut GitBrowser) {
+fn reset_browser_to_head_or_exit(browser: &mut git::Browser) {
     if let Err(e) = browser.head() {
         println!("Failed to set browser to HEAD: {:?}", e);
         std::process::exit(1);
     }
 }
 
-fn set_browser_history_or_exit(browser: &mut GitBrowser, commit_id: &str) {
+fn set_browser_history_or_exit(browser: &mut git::Browser, commit_id: &str) {
     // TODO: Might consider to not require resetting to HEAD when history is not at HEAD
     reset_browser_to_head_or_exit(browser);
     if let Err(e) = set_browser_history(browser, commit_id) {
@@ -88,7 +88,7 @@ fn set_browser_history_or_exit(browser: &mut GitBrowser, commit_id: &str) {
     }
 }
 
-fn set_browser_history(browser: &mut GitBrowser, commit_id: &str) -> Result<(), String> {
+fn set_browser_history(browser: &mut git::Browser, commit_id: &str) -> Result<(), String> {
     let oid = match Oid::from_str(commit_id) {
         Ok(oid) => oid,
         Err(e) => return Err(format!("{}", e)),
@@ -104,7 +104,7 @@ fn set_browser_history(browser: &mut GitBrowser, commit_id: &str) -> Result<(), 
     Ok(())
 }
 
-fn get_directory_or_exit(browser: &GitBrowser) -> Directory {
+fn get_directory_or_exit(browser: &git::Browser) -> Directory {
     match browser.get_directory() {
         Ok(dir) => return dir,
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,19 +8,19 @@
 //! Let's start surfing (and apologies for the `unwrap`s):
 //!
 //! ```
-//! use radicle_surf::vcs::git::{GitBrowser, Repository, Sha1};
+//! use radicle_surf::vcs::git;
 //! use radicle_surf::file_system::{Label, Path, SystemType};
 //! use radicle_surf::file_system::unsound;
 //! use pretty_assertions::assert_eq;
 //!
 //! // We're going to point to this repo.
-//! let repo = Repository::new("./data/git-platinum").expect("Failed to initialise repo");
+//! let repo = git::Repository::new("./data/git-platinum").expect("Failed to initialise repo");
 //!
 //! // Here we initialise a new Broswer for a the git repo.
-//! let mut browser = GitBrowser::new(repo).expect("Failed to initialise browser");
+//! let mut browser = git::Browser::new(repo).expect("Failed to initialise browser");
 //!
 //! // Set the history to a particular commit
-//! browser.commit(Sha1::new("80ded66281a4de2889cc07293a8f10947c6d57fe"))
+//! browser.commit(git::Sha1::new("80ded66281a4de2889cc07293a8f10947c6d57fe"))
 //!        .expect("Failed to set commit");
 //!
 //! // Get the snapshot of the directory for our current

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -37,7 +37,7 @@
 //! ```
 
 // Re-export git2 as sub-module
-pub use git2::{BranchType, Error as GitError, Oid, Time};
+pub use git2;
 
 pub mod error;
 
@@ -45,7 +45,6 @@ use crate::file_system;
 use crate::vcs;
 use crate::vcs::git::error::*;
 use crate::vcs::VCS;
-use git2;
 use nonempty::NonEmpty;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -663,7 +662,8 @@ impl Browser {
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{Branch, BranchName, BranchType, Browser, Repository};
+    /// use radicle_surf::vcs::git::{Branch, BranchName, Browser, Repository};
+    /// use radicle_surf::vcs::git::git2::{BranchType};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
     /// let mut browser = Browser::new(repo).unwrap();
@@ -810,7 +810,8 @@ impl Browser {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository, Oid, Sha1};
+    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository, Sha1};
+    /// use radicle_surf::vcs::git::git2::{Oid};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///
@@ -833,7 +834,8 @@ impl Browser {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository, Oid, Sha1};
+    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository, Sha1};
+    /// use radicle_surf::vcs::git::git2::{Oid};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -7,7 +7,7 @@
 //!
 //! let repo = Repository::new("./data/git-platinum")
 //!     .expect("Could not retrieve ./data/git-platinum as git repository");
-//! let browser = GitBrowser::new(repo).expect("Could not initialise Browser");
+//! let browser = Browser::new(repo).expect("Could not initialise Browser");
 //! let directory = browser.get_directory().expect("Could not render Directory");
 //! let mut directory_contents = directory.list_directory();
 //! directory_contents.sort();
@@ -115,10 +115,10 @@ impl<'repo> Repository {
     ///
     /// # Examples
     /// ```
-    /// use radicle_surf::vcs::git::{Branch, BranchName, GitBrowser, Repository};
+    /// use radicle_surf::vcs::git::{Branch, BranchName, Browser, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let browser = GitBrowser::new(repo).unwrap();
+    /// let browser = Browser::new(repo).unwrap();
     ///
     /// let mut branches = browser.list_branches(None).unwrap();
     /// branches.sort();
@@ -458,18 +458,18 @@ impl std::fmt::Debug for Repository {
 
 /// A `Browser` that uses [`Repository`](struct.Repository.html) as the underlying repository backend,
 /// `git2::Commit` as the artifact, and [`Error`](enum.Error.html) for error reporting.
-pub type GitBrowser = vcs::Browser<Repository, Commit, Error>;
+pub type Browser = vcs::Browser<Repository, Commit, Error>;
 
-impl GitBrowser {
+impl Browser {
     /// Create a new browser to interact with.
     ///
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, Repository};
+    /// use radicle_surf::vcs::git::{Browser, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let browser = GitBrowser::new(repo).unwrap();
+    /// let browser = Browser::new(repo).unwrap();
     /// ```
     pub fn new(repository: Repository) -> Result<Self, Error> {
         let history = repository.head()?;
@@ -484,15 +484,15 @@ impl GitBrowser {
         })
     }
 
-    /// Set the current `GitBrowser` history to the `HEAD` commit of the underlying repository.
+    /// Set the current `Browser` history to the `HEAD` commit of the underlying repository.
     ///
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, Repository};
+    /// use radicle_surf::vcs::git::{Browser, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let mut browser = GitBrowser::new(repo).unwrap();
+    /// let mut browser = Browser::new(repo).unwrap();
     ///
     /// // ensure we're at HEAD
     /// browser.head();
@@ -508,16 +508,16 @@ impl GitBrowser {
         Ok(())
     }
 
-    /// Set the current `GitBrowser` history to the [`BranchName`](struct.BranchName.html)
+    /// Set the current `Browser` history to the [`BranchName`](struct.BranchName.html)
     /// provided.
     ///
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{BranchName, GitBrowser, Repository};
+    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let mut browser = GitBrowser::new(repo).unwrap();
+    /// let mut browser = Browser::new(repo).unwrap();
     ///
     /// // ensure we're on 'master'
     /// browser.branch(BranchName::new("master"));
@@ -529,12 +529,12 @@ impl GitBrowser {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{BranchName, GitBrowser, Repository};
+    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let mut browser = GitBrowser::new(repo).unwrap();
+    /// let mut browser = Browser::new(repo).unwrap();
     /// browser
     ///     .branch(BranchName::new("origin/dev"))
     ///     .expect("Failed to change branch to dev");
@@ -578,7 +578,7 @@ impl GitBrowser {
         Ok(())
     }
 
-    /// Set the current `GitBrowser` history to the [`TagName`](struct.TagName.html)
+    /// Set the current `Browser` history to the [`TagName`](struct.TagName.html)
     /// provided.
     ///
     /// # Examples
@@ -586,10 +586,10 @@ impl GitBrowser {
     /// ```
     /// use git2::Oid;
     /// use radicle_surf::vcs::History;
-    /// use radicle_surf::vcs::git::{TagName, GitBrowser, Repository};
+    /// use radicle_surf::vcs::git::{TagName, Browser, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let mut browser = GitBrowser::new(repo).unwrap();
+    /// let mut browser = Browser::new(repo).unwrap();
     ///
     /// // Switch to "v0.3.0"
     /// browser.tag(TagName::new("v0.3.0")).expect("Failed to switch tag");
@@ -614,19 +614,19 @@ impl GitBrowser {
         Ok(())
     }
 
-    /// Set the current `GitBrowser` history to the [`Sha1`](struct.Sha1.html)
+    /// Set the current `Browser` history to the [`Sha1`](struct.Sha1.html)
     /// provided. The history will consist of a single [`Commit`](struct.Commit.html).
     ///
     /// # Examples
     ///
     /// ```
     /// use radicle_surf::file_system::{Label, SystemType};
-    /// use radicle_surf::vcs::git::{GitBrowser, Repository, Sha1};
+    /// use radicle_surf::vcs::git::{Browser, Repository, Sha1};
     /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
-    /// let mut browser = GitBrowser::new(repo).expect("Could not initialise Browser");
+    /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Set to the initial commit
     /// browser
@@ -663,10 +663,10 @@ impl GitBrowser {
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{Branch, BranchName, BranchType, GitBrowser, Repository};
+    /// use radicle_surf::vcs::git::{Branch, BranchName, BranchType, Browser, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let mut browser = GitBrowser::new(repo).unwrap();
+    /// let mut browser = Browser::new(repo).unwrap();
     ///
     /// let branches = browser.list_branches(None).unwrap();
     ///
@@ -708,10 +708,10 @@ impl GitBrowser {
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, Repository, TagName};
+    /// use radicle_surf::vcs::git::{Browser, Repository, TagName};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
-    /// let mut browser = GitBrowser::new(repo).unwrap();
+    /// let mut browser = Browser::new(repo).unwrap();
     ///
     /// let tags = browser.list_tags().unwrap();
     ///
@@ -742,7 +742,7 @@ impl GitBrowser {
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, Repository, Sha1};
+    /// use radicle_surf::vcs::git::{Browser, Repository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///
@@ -750,7 +750,7 @@ impl GitBrowser {
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-test as git repository");
-    /// let mut browser = GitBrowser::new(repo).expect("Could not initialise Browser");
+    /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Clamp the Browser to a particular commit
     /// browser.commit(Sha1::new("d6880352fc7fda8f521ae9b7357668b17bb5bad5")).expect("Failed to set
@@ -779,13 +779,13 @@ impl GitBrowser {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{GitBrowser, Repository, Sha1};
+    /// use radicle_surf::vcs::git::{Browser, Repository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
-    /// let mut browser = GitBrowser::new(repo).expect("Could not initialise Browser");
+    /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Set the browser history to the initial commit
     /// browser.commit(Sha1::new("d3464e33d75c75c99bfb90fa2e9d16efc0b7d0e3")).unwrap();
@@ -810,13 +810,13 @@ impl GitBrowser {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{BranchName, GitBrowser, Repository, Oid, Sha1};
+    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository, Oid, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
-    /// let mut browser = GitBrowser::new(repo).expect("Could not initialise Browser");
+    /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Check that last commit is the actual last commit even if head commit differs.
     /// browser.commit(Sha1::new("19bec071db6474af89c866a1bd0e4b1ff76e2b97")).unwrap();
@@ -833,13 +833,13 @@ impl GitBrowser {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{BranchName, GitBrowser, Repository, Oid, Sha1};
+    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository, Oid, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
-    /// let mut browser = GitBrowser::new(repo).expect("Could not initialise Browser");
+    /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Check that last commit is the actual last commit even if head commit differs.
     /// browser.commit(Sha1::new("19bec071db6474af89c866a1bd0e4b1ff76e2b97")).unwrap();

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -38,6 +38,7 @@
 
 // Re-export git2 as sub-module
 pub use git2;
+pub use git2::{BranchType, Error as Git2Error, Oid, Time};
 
 pub mod error;
 
@@ -583,9 +584,8 @@ impl Browser {
     /// # Examples
     ///
     /// ```
-    /// use git2::Oid;
     /// use radicle_surf::vcs::History;
-    /// use radicle_surf::vcs::git::{TagName, Browser, Repository};
+    /// use radicle_surf::vcs::git::{TagName, Browser, Oid, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
     /// let mut browser = Browser::new(repo).unwrap();
@@ -662,8 +662,7 @@ impl Browser {
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{Branch, BranchName, Browser, Repository};
-    /// use radicle_surf::vcs::git::git2::{BranchType};
+    /// use radicle_surf::vcs::git::{Branch, BranchType, BranchName, Browser, Repository};
     ///
     /// let repo = Repository::new("./data/git-platinum").unwrap();
     /// let mut browser = Browser::new(repo).unwrap();
@@ -810,8 +809,7 @@ impl Browser {
     /// ```
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{BranchName, Browser, Repository, Sha1};
-    /// use radicle_surf::vcs::git::git2::{Oid};
+    /// use radicle_surf::vcs::git::{BranchName, Browser, Oid, Repository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
     ///


### PR DESCRIPTION
With the drop of the `Git` prefix we move towards imports which should be qualified. As `git` is already in the module the prefix should be dropped consistently. Additionally `git2` is reexported again.