### PR TITLE
Add failing test case for repo with submodule

### DIFF
--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -947,3 +947,11 @@ impl Browser {
         ))
     }
 }
+
+#[test]
+fn submodule_failure() {
+    let repo = Repository::new(".").unwrap();
+    let browser = Browser::new(repo).unwrap();
+
+    browser.get_directory().unwrap();
+}

--- a/src/vcs/git/error.rs
+++ b/src/vcs/git/error.rs
@@ -40,6 +40,7 @@ impl From<git2::Error> for Error {
 #[derive(Debug)]
 pub(crate) enum TreeWalkError {
     NotBlob,
+    Commit,
     Git(Error),
 }
 


### PR DESCRIPTION
The `get_directory` call fails when called on a repository with a submodule in it. This test show-cases that for the radicle-surf repo itself.