### PR TITLE
Revparse Refactor

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,6 +7,7 @@ steps:
   command:
   # Ensure we have fetched the remote info in submodule
   - git submodule foreach "git fetch origin"
+  - git submodule update --remote
   - "cargo test --all"
   agents:
     production: "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,10 +5,6 @@ env:
 steps:
 - label: "Tests"
   command:
-  # Ensure we have fetched the remote info in submodule
-  - git submodule update --init --recursive
-  - git submodule foreach "git fetch origin"
-  - git submodule update --remote
   - "cargo test --all"
   agents:
     production: "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,6 +6,7 @@ steps:
 - label: "Tests"
   command:
   # Ensure we have fetched the remote info in submodule
+  - git submodule update --init --recursive
   - git submodule foreach "git fetch origin"
   - git submodule update --remote
   - "cargo test --all"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "data/git-platinum"]
 	path = data/git-platinum
 	url = https://github.com/radicle-dev/git-platinum.git
+	branch = master

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -93,14 +93,11 @@ fn set_browser_history(browser: &mut git::Browser, commit_id: &str) -> Result<()
         Ok(oid) => oid,
         Err(e) => return Err(format!("{}", e)),
     };
-    let commit = match browser
-        .get_history()
-        .find_in_history(&oid, |artifact| artifact.id)
-    {
+    let commit = match browser.get().find_in_history(&oid, |artifact| artifact.id) {
         Some(commit) => commit,
         None => return Err(format!("Git commit not found: {}", commit_id)),
     };
-    browser.set_history(History(NonEmpty::new(commit)));
+    browser.set(History(NonEmpty::new(commit)));
     Ok(())
 }
 

--- a/src/file_system/path/mod.rs
+++ b/src/file_system/path/mod.rs
@@ -3,6 +3,7 @@ use crate::nonempty::split_last;
 use nonempty::NonEmpty;
 use std::convert::TryFrom;
 use std::fmt;
+use std::ops::Deref;
 use std::path;
 use std::str::FromStr;
 
@@ -32,6 +33,14 @@ pub mod unsound;
 pub struct Label {
     pub(crate) label: String,
     pub(crate) hidden: bool,
+}
+
+impl Deref for Label {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.label
+    }
 }
 
 impl Label {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! use radicle_surf::file_system::{Label, Path, SystemType};
 //! use radicle_surf::file_system::unsound;
 //! use pretty_assertions::assert_eq;
+//! use std::str::FromStr;
 //!
 //! // We're going to point to this repo.
 //! let repo = git::Repository::new("./data/git-platinum").expect("Failed to initialise repo");
@@ -22,8 +23,10 @@
 //! let mut browser = git::Browser::new(repo).expect("Failed to initialise browser");
 //!
 //! // Set the history to a particular commit
-//! browser.commit(git::Sha1::new("80ded66281a4de2889cc07293a8f10947c6d57fe"))
-//!        .expect("Failed to set commit");
+//! let commit = git::Sha1::from_str(
+//!     "80ded66281a4de2889cc07293a8f10947c6d57fe"
+//! ).expect("Failed to parse SHA");
+//! browser.commit(commit).expect("Failed to set commit");
 //!
 //! // Get the snapshot of the directory for our current
 //! // HEAD of history.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! let mut browser = git::Browser::new(repo).expect("Failed to initialise browser");
 //!
 //! // Set the history to a particular commit
-//! let commit = git::Sha1::from_str(
+//! let commit = git::Oid::from_str(
 //!     "80ded66281a4de2889cc07293a8f10947c6d57fe"
 //! ).expect("Failed to parse SHA");
 //! browser.commit(commit).expect("Failed to set commit");

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -604,9 +604,47 @@ impl Browser {
         Ok(())
     }
 
+    /// Set a `Browser`'s `History` based on a
+    /// [revspec](https://git-scm.com/docs/git-rev-parse.html#_specifying_revisions).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use radicle_surf::file_system::{Label, SystemType};
+    /// use radicle_surf::file_system::unsound;
+    /// use radicle_surf::vcs::git::{Browser, Oid, Repository};
+    /// use std::str::FromStr;
+    ///
+    /// let repo = Repository::new("./data/git-platinum")
+    ///     .expect("Could not retrieve ./data/git-platinum as git repository");
+    /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
+    ///
+    /// browser
+    ///     .revspec("refs/remotes/origin/dev")
+    ///     .expect("Missing dev");
+    ///
+    /// let directory = browser.get_directory().unwrap();
+    /// let mut directory_contents = directory.list_directory();
+    /// directory_contents.sort();
+    ///
+    /// // We should only have src in our root
+    /// assert_eq!(
+    ///     directory_contents,
+    ///     vec![
+    ///         SystemType::file(unsound::label::new(".i-am-well-hidden")),
+    ///         SystemType::file(unsound::label::new(".i-too-am-hidden")),
+    ///         SystemType::file(unsound::label::new("README.md")),
+    ///         SystemType::directory(unsound::label::new("bin")),
+    ///         SystemType::file(unsound::label::new("here-we-are-on-a-dev-branch.lol")),
+    ///         SystemType::directory(unsound::label::new("src")),
+    ///         SystemType::directory(unsound::label::new("text")),
+    ///         SystemType::directory(unsound::label::new("this")),
+    ///     ]
+    /// );
+    /// ```
     pub fn revspec(&mut self, spec: &str) -> Result<(), Error> {
-        let rev = RevObject::from_revparse(&self.repository.0, spec)?;
-        self.rev(rev)?;
+        let history = self.get_history(spec.to_string())?;
+        self.set(history);
         Ok(())
     }
 

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -48,7 +48,7 @@ use crate::file_system::directory;
 use crate::tree::*;
 use crate::vcs;
 use crate::vcs::git::error::*;
-use crate::vcs::git::object::*;
+pub use crate::vcs::git::object::*;
 use crate::vcs::VCS;
 use nonempty::NonEmpty;
 use std::cmp::Ordering;
@@ -555,14 +555,18 @@ impl Browser {
     /// use radicle_surf::file_system::{Label, SystemType};
     /// use radicle_surf::vcs::git::{Browser, Repository, Sha1};
     /// use radicle_surf::file_system::unsound;
+    /// use std::str::FromStr;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
     /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
+    /// let commit = Sha1::from_str(
+    ///     "e24124b7538658220b5aaf3b6ef53758f0a106dc").expect("Failed to
+    /// parse SHA");
     /// // Set to the initial commit
     /// browser
-    ///     .commit(Sha1::new("e24124b7538658220b5aaf3b6ef53758f0a106dc"))
+    ///     .commit(commit)
     ///     .expect("Missing commit");
     ///
     /// let directory = browser.get_directory().unwrap();
@@ -662,6 +666,7 @@ impl Browser {
     /// use radicle_surf::vcs::git::{Browser, Repository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
+    /// use std::str::FromStr;
     ///
     /// use git2;
     ///
@@ -670,7 +675,10 @@ impl Browser {
     /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Clamp the Browser to a particular commit
-    /// browser.commit(Sha1::new("d6880352fc7fda8f521ae9b7357668b17bb5bad5")).expect("Failed to set
+    /// let commit = Sha1::from_str(
+    ///     "d6880352fc7fda8f521ae9b7357668b17bb5bad5"
+    /// ).expect("Failed to parse SHA");
+    /// browser.commit(commit).expect("Failed to set
     /// commit");
     ///
     /// let head_commit = browser.get_history().0.first().clone();
@@ -699,13 +707,17 @@ impl Browser {
     /// use radicle_surf::vcs::git::{Browser, Repository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
+    /// use std::str::FromStr;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
     /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Set the browser history to the initial commit
-    /// browser.commit(Sha1::new("d3464e33d75c75c99bfb90fa2e9d16efc0b7d0e3")).unwrap();
+    /// let commit = Sha1::from_str(
+    ///     "d3464e33d75c75c99bfb90fa2e9d16efc0b7d0e3"
+    /// ).expect("Failed to parse SHA");
+    /// browser.commit(commit).unwrap();
     ///
     /// let head_commit = browser.get_history().0.first().clone();
     ///
@@ -730,13 +742,17 @@ impl Browser {
     /// use radicle_surf::vcs::git::{BranchName, Browser, Oid, Repository, Sha1};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
+    /// use std::str::FromStr;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
     /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Check that last commit is the actual last commit even if head commit differs.
-    /// browser.commit(Sha1::new("19bec071db6474af89c866a1bd0e4b1ff76e2b97")).unwrap();
+    /// let commit = Sha1::from_str(
+    ///     "19bec071db6474af89c866a1bd0e4b1ff76e2b97"
+    /// ).expect("Could not parse SHA");
+    /// browser.commit(commit).unwrap();
     ///
     /// let expected_commit_id =
     ///     Oid::from_str("f3a089488f4cfd1a240a9c01b3fcc4c34a4e97b2").unwrap();
@@ -754,13 +770,17 @@ impl Browser {
     /// use radicle_surf::vcs::git::git2::{Oid};
     /// use radicle_surf::file_system::{Label, Path, SystemType};
     /// use radicle_surf::file_system::unsound;
+    /// use std::str::FromStr;
     ///
     /// let repo = Repository::new("./data/git-platinum")
     ///     .expect("Could not retrieve ./data/git-platinum as git repository");
     /// let mut browser = Browser::new(repo).expect("Could not initialise Browser");
     ///
     /// // Check that last commit is the actual last commit even if head commit differs.
-    /// browser.commit(Sha1::new("19bec071db6474af89c866a1bd0e4b1ff76e2b97")).unwrap();
+    /// let commit = Sha1::from_str(
+    ///     "19bec071db6474af89c866a1bd0e4b1ff76e2b97"
+    /// ).expect("Failed to parse SHA");
+    /// browser.commit(commit).unwrap();
     ///
     /// let expected_commit_id =
     ///     Oid::from_str("2429f097664f9af0c5b7b389ab998b2199ffa977").unwrap();

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -147,6 +147,10 @@ impl<'repo> Repository {
             .collect())
     }
 
+    pub fn from_revparse(&self, spec: &str) -> Result<RevObject, Error> {
+        RevObject::from_revparse(&self.0, spec)
+    }
+
     /// Get a particular `Commit`.
     pub(crate) fn get_commit(&'repo self, sha: Sha1) -> Result<git2::Commit<'repo>, Error> {
         let commit = self.0.find_commit(sha.value().clone())?;
@@ -643,6 +647,10 @@ impl Browser {
     /// ```
     pub fn list_tags(&self) -> Result<Vec<TagName>, Error> {
         self.repository.list_tags()
+    }
+
+    pub fn from_revparse(&self, spec: &str) -> Result<RevObject, Error> {
+        self.repository.from_revparse(spec)
     }
 
     /// Given a [`Path`](../../file_system/struct.Path.html) to a file, return the last `Commit`

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -1000,24 +1000,34 @@ mod tests {
         browser.revspec("master")?;
 
         let commit1 = git2::Oid::from_str("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
-        assert!(browser
-            .history
-            .find(|commit| if commit.id == commit1 {
-                Some(commit.clone())
-            } else {
-                None
-            })
-            .is_some());
+        assert!(
+            browser
+                .history
+                .find(|commit| if commit.id == commit1 {
+                    Some(commit.clone())
+                } else {
+                    None
+                })
+                .is_some(),
+            "commit_id={}, history =\n{:#?}",
+            commit1,
+            browser.history
+        );
 
         let commit2 = git2::Oid::from_str("d6880352fc7fda8f521ae9b7357668b17bb5bad5")?;
-        assert!(browser
-            .history
-            .find(|commit| if commit.id == commit2 {
-                Some(commit.clone())
-            } else {
-                None
-            })
-            .is_some());
+        assert!(
+            browser
+                .history
+                .find(|commit| if commit.id == commit2 {
+                    Some(commit.clone())
+                } else {
+                    None
+                })
+                .is_some(),
+            "commit_id={}, history =\n{:#?}",
+            commit2,
+            browser.history
+        );
 
         Ok(())
     }

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -1033,35 +1033,6 @@ mod tests {
     }
 
     #[test]
-    fn test_rev_master_with_date() -> Result<(), Error> {
-        let repo = Repository::new("./data/git-platinum")?;
-        let mut browser = Browser::new(repo)?;
-        browser.revspec("master@{yesterday}")?;
-
-        let commit1 = git2::Oid::from_str("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
-        assert!(browser
-            .history
-            .find(|commit| if commit.id == commit1 {
-                Some(commit.clone())
-            } else {
-                None
-            })
-            .is_some());
-
-        let commit2 = git2::Oid::from_str("d6880352fc7fda8f521ae9b7357668b17bb5bad5")?;
-        assert!(browser
-            .history
-            .find(|commit| if commit.id == commit2 {
-                Some(commit.clone())
-            } else {
-                None
-            })
-            .is_some());
-
-        Ok(())
-    }
-
-    #[test]
     fn test_rev_commit() -> Result<(), Error> {
         let repo = Repository::new("./data/git-platinum")?;
         let mut browser = Browser::new(repo)?;

--- a/src/vcs/git/error.rs
+++ b/src/vcs/git/error.rs
@@ -6,6 +6,7 @@ pub enum Error {
     EmptyCommitHistory,
     NotBranch,
     NotTag,
+    RevParseFailure,
     Utf8Error(str::Utf8Error),
     FileSystem(file_error::Error),
     FileDiffException,

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -225,50 +225,6 @@ impl<'repo> TryFrom<git2::Tag<'repo>> for Tag {
     }
 }
 
-/// A newtype wrapper over `String` to separate out
-/// the fact that a caller wants to fetch a commit.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Sha1(git2::Oid);
-
-impl Sha1 {
-    pub fn value(&self) -> &git2::Oid {
-        &self.0
-    }
-}
-
-impl str::FromStr for Sha1 {
-    type Err = git2::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let oid = git2::Oid::from_str(s)?;
-        Ok(Sha1(oid))
-    }
-}
-
-/// An enumeration of git objects we can fetch and turn
-/// into a [`History`](struct.History.html).
-#[derive(Debug, Clone)]
-pub enum Object {
-    Branch(BranchName),
-    Tag(TagName),
-}
-
-impl Object {
-    pub fn branch(name: &str) -> Self {
-        Object::Branch(BranchName::new(name))
-    }
-
-    pub fn tag(name: &str) -> Self {
-        Object::Tag(TagName::new(name))
-    }
-
-    pub fn name(&self) -> String {
-        match self {
-            Object::Branch(name) => name.0.clone(),
-            Object::Tag(name) => name.0.clone(),
-        }
-    }
-}
 
 pub enum RevObject {
     Branch(Branch),

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -1,0 +1,265 @@
+use crate::vcs::git::error::*;
+use git2;
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::str;
+
+#[derive(Clone)]
+pub struct Signature {
+    pub name: String,
+    pub email: String,
+    pub time: git2::Time,
+}
+
+impl std::fmt::Debug for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Signature {{ name: {}, email: {} }}",
+            self.name, self.email
+        )
+    }
+}
+
+impl<'repo> TryFrom<git2::Signature<'repo>> for Signature {
+    type Error = str::Utf8Error;
+
+    fn try_from(signature: git2::Signature) -> Result<Self, Self::Error> {
+        let name = str::from_utf8(signature.name_bytes())?.into();
+        let email = str::from_utf8(signature.email_bytes())?.into();
+        let time = signature.when();
+
+        Ok(Signature { name, email, time })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Commit {
+    pub id: git2::Oid,
+    pub author: Signature,
+    pub committer: Signature,
+    pub message: String,
+    pub summary: String,
+}
+
+impl<'repo> TryFrom<git2::Commit<'repo>> for Commit {
+    type Error = Error;
+
+    fn try_from(commit: git2::Commit) -> Result<Self, Self::Error> {
+        let id = commit.id();
+        let author = Signature::try_from(commit.author())?;
+        let committer = Signature::try_from(commit.committer())?;
+        let message_raw = commit.message_bytes();
+        let message = str::from_utf8(message_raw)?.into();
+        let summary_raw = commit.summary_bytes().expect("TODO");
+        let summary = str::from_utf8(summary_raw)?.into();
+
+        Ok(Commit {
+            id,
+            author,
+            committer,
+            message,
+            summary,
+        })
+    }
+}
+
+/// A newtype wrapper over `String` to separate out
+/// the fact that a caller wants to fetch a branch.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BranchName(String);
+
+impl TryFrom<&[u8]> for BranchName {
+    type Error = str::Utf8Error;
+
+    fn try_from(name: &[u8]) -> Result<Self, Self::Error> {
+        str::from_utf8(name).map(|name| Self(String::from(name)))
+    }
+}
+
+impl BranchName {
+    pub fn new(name: &str) -> Self {
+        BranchName(name.into())
+    }
+
+    pub fn name(&self) -> String {
+        self.0.clone()
+    }
+}
+
+/// The combination of a branch's name and where its locality (remote or local).
+///
+/// **Note**: The `PartialOrd` and `Ord` implementations compare on `BranchName`
+/// only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Branch {
+    pub name: BranchName,
+    pub locality: git2::BranchType,
+}
+
+impl PartialOrd for Branch {
+    fn partial_cmp(&self, other: &Branch) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Branch {
+    fn cmp(&self, other: &Branch) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl Branch {
+    /// Helper to create a remote `Branch` with a name
+    pub fn remote(name: BranchName) -> Self {
+        Branch {
+            name,
+            locality: git2::BranchType::Remote,
+        }
+    }
+
+    /// Helper to create a remote `Branch` with a name
+    pub fn local(name: BranchName) -> Self {
+        Branch {
+            name,
+            locality: git2::BranchType::Local,
+        }
+    }
+
+    fn from_reference(reference: &git2::Reference) -> Option<Result<Branch, str::Utf8Error>> {
+        if !reference.is_branch() {
+            return None;
+        }
+
+        let name = BranchName::try_from(reference.name_bytes());
+        let locality = if reference.is_remote() {
+            git2::BranchType::Remote
+        } else {
+            git2::BranchType::Local
+        };
+        Some(name.map(|name| Branch { name, locality }))
+    }
+}
+
+/// A newtype wrapper over `String` to separate out
+/// the fact that a caller wants to fetch a tag.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TagName(String);
+
+impl TryFrom<&[u8]> for TagName {
+    type Error = str::Utf8Error;
+
+    fn try_from(name: &[u8]) -> Result<Self, Self::Error> {
+        str::from_utf8(name).map(|name| Self(String::from(name)))
+    }
+}
+
+impl TagName {
+    pub fn new(name: &str) -> Self {
+        TagName(name.into())
+    }
+
+    pub fn name(&self) -> String {
+        self.0.clone()
+    }
+}
+
+pub struct Tag {
+    pub id: git2::Oid,
+    pub name: TagName,
+    pub tagger: Option<Signature>,
+    pub message: Option<String>,
+}
+
+impl<'repo> TryFrom<git2::Tag<'repo>> for Tag {
+    type Error = str::Utf8Error;
+
+    fn try_from(tag: git2::Tag) -> Result<Self, Self::Error> {
+        let id = tag.id();
+
+        let name = TagName::try_from(tag.name_bytes())?;
+
+        let tagger = tag.tagger().map(Signature::try_from).transpose()?;
+
+        let message = tag
+            .message_bytes()
+            .map(str::from_utf8)
+            .transpose()?
+            .map(|message| message.into());
+
+        Ok(Tag {
+            id,
+            name,
+            tagger,
+            message,
+        })
+    }
+}
+
+/// A newtype wrapper over `String` to separate out
+/// the fact that a caller wants to fetch a commit.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Sha1(git2::Oid);
+
+impl Sha1 {
+    pub fn value(&self) -> &git2::Oid {
+        &self.0
+    }
+}
+
+/// An enumeration of git objects we can fetch and turn
+/// into a [`History`](struct.History.html).
+#[derive(Debug, Clone)]
+pub enum Object {
+    Branch(BranchName),
+    Tag(TagName),
+}
+
+impl Object {
+    pub fn branch(name: &str) -> Self {
+        Object::Branch(BranchName::new(name))
+    }
+
+    pub fn tag(name: &str) -> Self {
+        Object::Tag(TagName::new(name))
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            Object::Branch(name) => name.0.clone(),
+            Object::Tag(name) => name.0.clone(),
+        }
+    }
+}
+
+pub enum RevObject {
+    Branch(Branch),
+    Tag(Tag),
+    Commit(Commit),
+}
+
+impl RevObject {
+    pub fn from_revparse(repo: git2::Repository, spec: &str) -> Result<Self, Error> {
+        let (object, optional_ref) = repo.revparse_ext(spec)?;
+
+        match optional_ref {
+            Some(reference) => match Branch::from_reference(&reference) {
+                Some(branch_result) => Ok(RevObject::Branch(branch_result?)),
+                None => Err(Error::RevParseFailure),
+            },
+            None => {
+                let tag = object.into_tag().map(Tag::try_from);
+                match tag {
+                    Ok(tag) => Ok(RevObject::Tag(tag?)),
+                    Err(object) => {
+                        let commit = object.into_commit().map(Commit::try_from);
+                        match commit {
+                            Ok(commit) => Ok(RevObject::Commit(commit?)),
+                            Err(_object) => Err(Error::RevParseFailure),
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -207,6 +207,15 @@ impl Sha1 {
     }
 }
 
+impl str::FromStr for Sha1 {
+    type Err = git2::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let oid = git2::Oid::from_str(s)?;
+        Ok(Sha1(oid))
+    }
+}
+
 /// An enumeration of git objects we can fetch and turn
 /// into a [`History`](struct.History.html).
 #[derive(Debug, Clone)]

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -225,35 +225,71 @@ impl<'repo> TryFrom<git2::Tag<'repo>> for Tag {
     }
 }
 
-
+/// A `RevObject` encapsulates the idea of providing a "revspec" to git and
+/// getting back the desired object.
+///
+/// `RevObject` can in turn be used by [`rev`](type.Browser.html#method.rev) to set the `Browser`'s
+/// `History` with the object.
+///
+/// See here for the [specifying revision](https://git-scm.com/docs/git-rev-parse.html#_specifying_revisions).
 pub enum RevObject {
+    /// A `Branch` revision.
     Branch(Branch),
+    /// A `Tag` revision.
     Tag(Tag),
+    /// A `Commit` revision.
     Commit(Commit),
 }
 
 impl RevObject {
+    /// Create a `RevObject` by calling
+    /// [`revparse_ext`](https://docs.rs/git2/0.11.0/git2/struct.Repository.html#method.revparse_ext)
+    /// and attempting to turn the resulting `Object` into a `Tag` or a `Commit`. If this fails we
+    /// attempt to see if the `Reference` is present and is a `Branch`.
+    ///
+    /// # Failures
+    ///
+    /// This operation will fail if any of the `git2` commands fail, if any conversions fail,
+    /// or we fail to find a matching object or reference (resulting in `Error::RevParseFailure`).
     pub fn from_revparse(repo: &git2::Repository, spec: &str) -> Result<Self, Error> {
         let (object, optional_ref) = repo.revparse_ext(spec)?;
 
-        match optional_ref {
-            Some(reference) => match Branch::from_reference(&reference) {
-                Some(branch_result) => Ok(RevObject::Branch(branch_result?)),
-                None => Err(Error::RevParseFailure),
-            },
-            None => {
-                let tag = object.into_tag().map(Tag::try_from);
-                match tag {
-                    Ok(tag) => Ok(RevObject::Tag(tag?)),
-                    Err(object) => {
-                        let commit = object.into_commit().map(Commit::try_from);
-                        match commit {
-                            Ok(commit) => Ok(RevObject::Commit(commit?)),
-                            Err(_object) => Err(Error::RevParseFailure),
-                        }
-                    }
+        let tag = object.into_tag().map(Tag::try_from);
+        match tag {
+            Ok(tag) => Ok(RevObject::Tag(tag?)),
+            Err(object) => {
+                let commit = object.into_commit().map(Commit::try_from);
+                match commit {
+                    Ok(commit) => Ok(RevObject::Commit(commit?)),
+                    Err(_object) => match optional_ref {
+                        Some(reference) => Branch::try_from(reference).map(RevObject::Branch),
+                        None => Err(Error::RevParseFailure),
+                    },
                 }
             }
+        }
+    }
+
+    /// Peel back a `RevObject` into a `git2::Commit`.
+    ///
+    /// In the case of the `RevObject` itself being a `Commit` it is trivial.
+    /// In the case of the `RevObject` being a `Tag` or `Branch`, we first get the object/reference
+    /// and then get the commit it points to.
+    pub(crate) fn into_commit(self, repo: &git2::Repository) -> Result<git2::Commit, Error> {
+        match self {
+            RevObject::Branch(branch) => {
+                let reference = repo
+                    .find_branch(&branch.name.0, branch.locality)?
+                    .into_reference();
+                let commit = reference.peel_to_commit()?;
+                Ok(commit)
+            }
+            RevObject::Tag(tag) => {
+                let object = repo.find_tag(tag.id)?.into_object();
+                let commit = object.peel_to_commit()?;
+                Ok(commit)
+            }
+            RevObject::Commit(commit) => Ok(repo.find_commit(commit.id)?),
         }
     }
 }

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -239,7 +239,7 @@ pub enum RevObject {
 }
 
 impl RevObject {
-    pub fn from_revparse(repo: git2::Repository, spec: &str) -> Result<Self, Error> {
+    pub fn from_revparse(repo: &git2::Repository, spec: &str) -> Result<Self, Error> {
         let (object, optional_ref) = repo.revparse_ext(spec)?;
 
         match optional_ref {

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -112,7 +112,7 @@ pub struct Browser<Repo, A, Error> {
 
 impl<Repo, A, Error> Browser<Repo, A, Error> {
     /// Get the current `History` the `Browser` is viewing.
-    pub fn get_history(&self) -> History<A>
+    pub fn get(&self) -> History<A>
     where
         A: Clone,
     {
@@ -120,7 +120,7 @@ impl<Repo, A, Error> Browser<Repo, A, Error> {
     }
 
     /// Set the `History` the `Browser` should view.
-    pub fn set_history(&mut self, history: History<A>) {
+    pub fn set(&mut self, history: History<A>) {
         self.history = history;
     }
 
@@ -130,7 +130,7 @@ impl<Repo, A, Error> Browser<Repo, A, Error> {
     }
 
     /// Modify the `History` in this `Browser`.
-    pub fn modify_history<F>(&mut self, f: F)
+    pub fn modify<F>(&mut self, f: F)
     where
         F: Fn(&History<A>) -> History<A>,
     {
@@ -144,7 +144,7 @@ impl<Repo, A, Error> Browser<Repo, A, Error> {
         A: Clone,
         F: Fn(&History<A>) -> Option<History<A>>,
     {
-        self.modify_history(|history| f(history).unwrap_or_else(|| default_history.clone()))
+        self.modify(|history| f(history).unwrap_or_else(|| default_history.clone()))
     }
 }
 


### PR DESCRIPTION
Fixes #55 

Introduce `RevObject` which is created via https://git-scm.com/docs/git-rev-parse.html#_specifying_revisions.

This surfaced some silly things in the API so I removed some things that aren't needed such as Object, Sha1, and de-duplicated some naming.

All the object related code is now under `vcs::git::object`.

Most importantly @xla: you can replace [this](https://github.com/radicle-dev/radicle-upstream/blob/master/proxy/src/schema/mod.rs#L111-L115) with `browser.revspec(revision)` :)