### PR TITLE
Add 'thiserror' library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "GPL-3.0-only"
 [dependencies]
 git2 = "0.12"
 nonempty = "0.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -5,8 +5,10 @@ use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::ops::Deref;
 use std::rc::Rc;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("A diff error occurred: {reason}")]
 pub struct DiffError {
     reason: String,
 }

--- a/src/file_system/error.rs
+++ b/src/file_system/error.rs
@@ -3,6 +3,8 @@
 //! These errors occur due to [`Label`] and [`Path`] parsing when using their respective `TryFrom`
 //! instances.
 
+use thiserror::Error;
+
 pub(crate) const EMPTY_PATH: Error = Error::Path(Path::Empty);
 
 pub(crate) const INVALID_UTF8: Error = Error::Label(Label::InvalidUTF8);
@@ -10,40 +12,34 @@ pub(crate) const EMPTY_LABEL: Error = Error::Label(Label::Empty);
 pub(crate) const CONTAINS_SLASH: Error = Error::Label(Label::ContainsSlash);
 
 /// Error type for all file system errors that can occur.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Error {
     /// A `Label` specific error for parsing a [`Label`].
-    Label(Label),
+    #[error("Label error: {0}")]
+    Label(#[from] Label),
     /// A `Path` specific error for parsing a [`Path`].
-    Path(Path),
-}
-
-impl From<Label> for Error {
-    fn from(err: Label) -> Self {
-        Error::Label(err)
-    }
-}
-
-impl From<Path> for Error {
-    fn from(err: Path) -> Self {
-        Error::Path(err)
-    }
+    #[error("Path error: {0}")]
+    Path(#[from] Path),
 }
 
 /// Parse errors for when parsing a string to a [`Path`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Path {
     /// An error signifying that a [`Path`] is empty.
+    #[error("Path is empty")]
     Empty,
 }
 
 /// Parse errors for when parsing a string to a [`Label`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Label {
     /// An error signifying that a [`Label`] is contains invalid UTF-8.
+    #[error("Label contains invalid UTF-8")]
     InvalidUTF8,
     /// An error signifying that a [`Label`] contains a `/`.
+    #[error("Label contains a slash")]
     ContainsSlash,
     /// An error signifying that a [`Label`] is empty.
+    #[error("Label is empty")]
     Empty,
 }

--- a/src/file_system/error.rs
+++ b/src/file_system/error.rs
@@ -1,45 +1,53 @@
 //! Errors that can occur within the file system logic.
 //!
-//! These errors occur due to [`Label`] and [`Path`] parsing when using their respective `TryFrom`
-//! instances.
+//! These errors occur due to [`Label`](super::path::Label) and [`Path`](super::path::Path) parsing
+//! when using their respective `TryFrom` instances.
 
+use std::ffi::OsStr;
 use thiserror::Error;
 
-pub(crate) const EMPTY_PATH: Error = Error::Path(Path::Empty);
+pub(crate) const EMPTY_PATH: Error = Error::Path(PathError::Empty);
+pub(crate) const EMPTY_LABEL: Error = Error::Label(LabelError::Empty);
 
-pub(crate) const INVALID_UTF8: Error = Error::Label(Label::InvalidUTF8);
-pub(crate) const EMPTY_LABEL: Error = Error::Label(Label::Empty);
-pub(crate) const CONTAINS_SLASH: Error = Error::Label(Label::ContainsSlash);
+/// Build an [`Error::Label(LabelError::InvalidUTF8)`] from an [`OsStr`](std::ffi::OsStr)
+pub(crate) fn label_invalid_utf8(item: &OsStr) -> Error {
+    Error::Label(LabelError::InvalidUTF8(item.to_string_lossy().into()))
+}
+
+/// Build an [`Error::Label(LabelError::ContainsSlash)`] from a [`str`]
+pub(crate) fn label_has_slash(item: &str) -> Error {
+    Error::Label(LabelError::ContainsSlash(item.into()))
+}
 
 /// Error type for all file system errors that can occur.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Error {
-    /// A `Label` specific error for parsing a [`Label`].
+    /// A `LabelError` specific error for parsing a [`Path`](super::path::Label).
     #[error("Label error: {0}")]
-    Label(#[from] Label),
-    /// A `Path` specific error for parsing a [`Path`].
+    Label(#[from] LabelError),
+    /// A `PathError` specific error for parsing a [`Path`](super::path::Path).
     #[error("Path error: {0}")]
-    Path(#[from] Path),
+    Path(#[from] PathError),
 }
 
-/// Parse errors for when parsing a string to a [`Path`].
+/// Parse errors for when parsing a string to a [`Path`](super::path::Path).
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum Path {
-    /// An error signifying that a [`Path`] is empty.
+pub enum PathError {
+    /// An error signifying that a [`Path`](super::path::Path) is empty.
     #[error("Path is empty")]
     Empty,
 }
 
-/// Parse errors for when parsing a string to a [`Label`].
+/// Parse errors for when parsing a string to a [`Label`](super::path::Label).
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum Label {
-    /// An error signifying that a [`Label`] is contains invalid UTF-8.
-    #[error("Label contains invalid UTF-8")]
-    InvalidUTF8,
-    /// An error signifying that a [`Label`] contains a `/`.
-    #[error("Label contains a slash")]
-    ContainsSlash,
-    /// An error signifying that a [`Label`] is empty.
+pub enum LabelError {
+    /// An error signifying that a [`Label`](super::path::Label) is contains invalid UTF-8.
+    #[error("Label contains invalid UTF-8: {0}")]
+    InvalidUTF8(String),
+    /// An error signifying that a [`Label`](super::path::Label) contains a `/`.
+    #[error("Label contains a slash: {0}")]
+    ContainsSlash(String),
+    /// An error signifying that a [`Label`](super::path::Label) is empty.
     #[error("Label is empty")]
     Empty,
 }

--- a/src/file_system/path/mod.rs
+++ b/src/file_system/path/mod.rs
@@ -79,7 +79,7 @@ impl TryFrom<&str> for Label {
         if item.is_empty() {
             Err(error::EMPTY_LABEL)
         } else if item.contains('/') {
-            Err(error::CONTAINS_SLASH)
+            Err(error::label_has_slash(item))
         } else {
             Ok(Label {
                 label: item.into(),
@@ -374,7 +374,7 @@ impl TryFrom<path::PathBuf> for Path {
     fn try_from(path_buf: path::PathBuf) -> Result<Self, Self::Error> {
         let mut path = Path::root();
         for p in path_buf.iter() {
-            let p = p.to_str().ok_or(error::INVALID_UTF8)?;
+            let p = p.to_str().ok_or_else(|| error::label_invalid_utf8(p))?;
             let l = Label::try_from(p)?;
             path.push(l);
         }

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -2,6 +2,7 @@ use crate::vcs::git::error::*;
 use git2;
 use std::cmp::Ordering;
 use std::convert::TryFrom;
+use std::fmt;
 use std::str;
 
 /// `Author` is the static information of a [`git2::Signature`].
@@ -78,6 +79,12 @@ impl<'repo> TryFrom<git2::Commit<'repo>> for Commit {
 /// A newtype wrapper over `String` to separate out the fact that a caller wants to fetch a branch.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BranchName(String);
+
+impl fmt::Display for BranchName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl TryFrom<&[u8]> for BranchName {
     type Error = str::Utf8Error;
@@ -164,6 +171,12 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Branch {
 /// A newtype wrapper over `String` to separate out the fact that a caller wants to fetch a tag.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TagName(String);
+
+impl fmt::Display for TagName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl TryFrom<&[u8]> for TagName {
     type Error = str::Utf8Error;


### PR DESCRIPTION
In order to update the doctests to be in line with the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark) (see #77), this crate's error types need to be updated.

This pull request converts existing error types to conform with the [thiserror](https://crates.io/crates/thiserror) API: see #76. There are no further adjustments to the structure of the errors, however now that they all implement `std::error::Error` and `std::fmt::Display`.

Once this change is merged I can open an additional pull request to fix the doctests.
