### PR TITLE
Make error enums non exhaustive

### DIFF
--- a/src/file_system/error.rs
+++ b/src/file_system/error.rs
@@ -40,6 +40,7 @@ pub(crate) fn label_has_slash(item: &str) -> Error {
 
 /// Error type for all file system errors that can occur.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// A `LabelError` specific error for parsing a
     /// [`Path`](super::path::Label).
@@ -52,6 +53,7 @@ pub enum Error {
 
 /// Parse errors for when parsing a string to a [`Path`](super::path::Path).
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum PathError {
     /// An error signifying that a [`Path`](super::path::Path) is empty.
     #[error("Path is empty")]
@@ -60,6 +62,7 @@ pub enum PathError {
 
 /// Parse errors for when parsing a string to a [`Label`](super::path::Label).
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum LabelError {
     /// An error signifying that a [`Label`](super::path::Label) is contains
     /// invalid UTF-8.

--- a/src/vcs/git/error.rs
+++ b/src/vcs/git/error.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 
 /// Enumeration of errors that can occur in operations from [`crate::vcs::git`].
 #[derive(Debug, PartialEq, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// The user tried to fetch a branch, but the name provided does not
     /// exist as a branch. This could mean that the branch does not exist
@@ -67,6 +68,7 @@ pub enum Error {
 ///
 /// In the of `Git` we abort both computations.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub(crate) enum TreeWalkError {
     #[error("Entry is not a blob")]
     NotBlob,


### PR DESCRIPTION
I have added `[non_exhaustive]` to the Error types. Let me know if there are any other additions needed.