### PR TITLE
Fintan/ownership

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 git2 = "0.12"
 thiserror = "1.0"
-nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "fe71f138ed4defc49a93157a1739279ccefad722" }
+nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "9c65e9fec82b9089d3a76f867e4cc93ede76a5a9" }
 
 [dev-dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,5 @@ thiserror = "1.0"
 nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "9c65e9fec82b9089d3a76f867e4cc93ede76a5a9" }
 
 [dev-dependencies]
-log = "0.4"
 pretty_assertions = "0.6"
 proptest = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ license = "GPL-3.0-or-later"
 [dependencies]
 git2 = "0.12"
 thiserror = "1.0"
-nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "e6372daa62b8b4955861744e1067c8873e8c185e" }
+nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "fe71f138ed4defc49a93157a1739279ccefad722" }
 
 [dev-dependencies]
+log = "0.4"
 pretty_assertions = "0.6"
 proptest = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 git2 = "0.12"
-nonempty = "0.2"
 thiserror = "1.0"
+nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "325b1185db258498b156ba9d13417e0588d41357" }
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 git2 = "0.12"
 thiserror = "1.0"
-nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "325b1185db258498b156ba9d13417e0588d41357" }
+nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "e6372daa62b8b4955861744e1067c8873e8c185e" }
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 git2 = "0.12"
 thiserror = "1.0"
-nonempty = { git = "https://github.com/cloudhead/nonempty.git", rev = "9c65e9fec82b9089d3a76f867e4cc93ede76a5a9" }
+nonempty = "0.4"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -325,7 +325,7 @@ mod tests {
         let directory = Directory::root();
 
         let mut new_directory = Directory::root();
-        new_directory.insert_file(&unsound::path::new("banana.rs"), File::new(b"use banana"));
+        new_directory.insert_file(unsound::path::new("banana.rs"), File::new(b"use banana"));
 
         let diff = Diff::diff(directory, new_directory).expect("diff failed");
 
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn test_delete_file() {
         let mut directory = Directory::root();
-        directory.insert_file(&unsound::path::new("banana.rs"), File::new(b"use banana"));
+        directory.insert_file(unsound::path::new("banana.rs"), File::new(b"use banana"));
 
         let new_directory = Directory::root();
 
@@ -380,10 +380,10 @@ mod tests {
     #[test]
     fn test_modify_file() {
         let mut directory = Directory::root();
-        directory.insert_file(&unsound::path::new("banana.rs"), File::new(b"use banana"));
+        directory.insert_file(unsound::path::new("banana.rs"), File::new(b"use banana"));
 
         let mut new_directory = Directory::root();
-        new_directory.insert_file(&unsound::path::new("banana.rs"), File::new(b"use banana;"));
+        new_directory.insert_file(unsound::path::new("banana.rs"), File::new(b"use banana;"));
 
         let diff = Diff::diff(directory, new_directory).expect("diff failed");
 
@@ -406,7 +406,7 @@ mod tests {
 
         let mut new_directory = Directory::root();
         new_directory.insert_file(
-            &unsound::path::new("src/banana.rs"),
+            unsound::path::new("src/banana.rs"),
             File::new(b"use banana"),
         );
 
@@ -429,7 +429,7 @@ mod tests {
     fn test_delete_directory() {
         let mut directory = Directory::root();
         directory.insert_file(
-            &unsound::path::new("src/banana.rs"),
+            unsound::path::new("src/banana.rs"),
             File::new(b"use banana"),
         );
 
@@ -454,13 +454,13 @@ mod tests {
     fn test_modify_file_directory() {
         let mut directory = Directory::root();
         directory.insert_file(
-            &unsound::path::new("src/banana.rs"),
+            unsound::path::new("src/banana.rs"),
             File::new(b"use banana"),
         );
 
         let mut new_directory = Directory::root();
         new_directory.insert_file(
-            &unsound::path::new("src/banana.rs"),
+            unsound::path::new("src/banana.rs"),
             File::new(b"use banana;"),
         );
 

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -43,8 +43,8 @@
 //! let file_system_mod = fs::File::new(b"pub mod directory;\npub mod error;\nmod path;");
 //!
 //! directory.insert_files(&[], root_files);
-//! directory.insert_file(&unsound::path::new("src/lib.rs"), lib.clone());
-//! directory.insert_file(&unsound::path::new("src/file_system/mod.rs"), file_system_mod);
+//! directory.insert_file(unsound::path::new("src/lib.rs"), lib.clone());
+//! directory.insert_file(unsound::path::new("src/file_system/mod.rs"), file_system_mod);
 //!
 //! // With a directory in place we can begin to operate on it
 //! // The first we will do is list what contents are at the root.
@@ -63,7 +63,7 @@
 //! // We can then go down one level to explore sub-directories
 //! // Note here that we can use `Path::new`, since there's guranteed to be a `Label`,
 //! // although we cheated and created the label unsafely.
-//! let src = directory.find_directory(&fs::Path::new(unsound::label::new("src")));
+//! let src = directory.find_directory(fs::Path::new(unsound::label::new("src")));
 //!
 //! // Ensure that we found the src directory
 //! assert!(src.is_some());
@@ -82,25 +82,25 @@
 //!
 //! // We can dive down to 'file_system' either from the root or src, they should be the same.
 //! assert_eq!(
-//!     src.find_directory(&unsound::path::new("file_system")),
-//!     directory.find_directory(&unsound::path::new("src/file_system")),
+//!     src.find_directory(unsound::path::new("file_system")),
+//!     directory.find_directory(unsound::path::new("src/file_system")),
 //! );
 //!
 //! // We can also find files
 //! assert_eq!(
-//!     src.find_file(&unsound::path::new("lib.rs")),
+//!     src.find_file(unsound::path::new("lib.rs")),
 //!     Some(lib)
 //! );
 //!
 //! // From anywhere
 //! assert_eq!(
-//!     directory.find_file(&unsound::path::new("src/file_system/mod.rs")),
-//!     src.find_file(&unsound::path::new("file_system/mod.rs")),
+//!     directory.find_file(unsound::path::new("src/file_system/mod.rs")),
+//!     src.find_file(unsound::path::new("file_system/mod.rs")),
 //! );
 //!
 //! // And we can also check the size of directories and files
 //! assert_eq!(
-//!     directory.find_file(&unsound::path::new("src/file_system/mod.rs")).map(|f| f.size()),
+//!     directory.find_file(unsound::path::new("src/file_system/mod.rs")).map(|f| f.size()),
 //!     Some(43),
 //! );
 //!

--- a/src/file_system/directory.rs
+++ b/src/file_system/directory.rs
@@ -488,16 +488,17 @@ impl Directory {
     pub fn insert_files(&mut self, directory_path: &[Label], files: NonEmpty<(Label, File)>) {
         match NonEmpty::from_slice(directory_path) {
             None => {
-                for (file_name, file) in files.iter() {
-                    self.insert_file(&Path::new(file_name.clone()), file.clone())
+                for (file_name, file) in files.into_iter() {
+                    self.insert_file(&Path::new(file_name), file)
                 }
             },
-            Some(directory_path) => {
-                for (file_name, file) in files.iter() {
-                    let mut file_path = Path(directory_path.clone());
-                    file_path.push(file_name.clone());
+            Some(path) => {
+                for (file_name, file) in files.into_iter() {
+                    // The clone is necessary here because we use it as a prefix.
+                    let mut file_path = Path(path.clone());
+                    file_path.push(file_name);
 
-                    self.insert_file(&file_path, file.clone())
+                    self.insert_file(&file_path, file)
                 }
             },
         }
@@ -507,14 +508,16 @@ impl Directory {
         let mut directory: Self = Directory::root();
 
         for (path, files) in files.into_iter() {
-            for (file_name, file) in files.iter() {
+            for (file_name, file) in files.into_iter() {
                 let mut file_path = path.clone();
-                file_path.push(file_name.clone());
+
                 if path.is_root() {
-                    directory.insert_file(&Path::new(file_name.clone()), file.clone())
+                    file_path.push(file_name);
                 } else {
-                    directory.insert_file(&file_path, file.clone())
+                    file_path = Path::new(file_name);
                 }
+
+                directory.insert_file(&file_path, file)
             }
         }
 

--- a/src/file_system/directory.rs
+++ b/src/file_system/directory.rs
@@ -361,8 +361,8 @@ impl Directory {
     /// // We shouldn't be able to find a file that doesn't exist
     /// assert_eq!(directory.find_file(&unsound::path::new("foo/bar/qux.rs")), None);
     /// ```
-    pub fn find_file(&self, path: &Path) -> Option<File> {
-        self.sub_directories.find_node(&path.0).cloned()
+    pub fn find_file(&self, path: Path) -> Option<File> {
+        self.sub_directories.find_node(path.0).cloned()
     }
 
     /// Find a `Directory` in the directory given the [`Path`] to the
@@ -400,9 +400,9 @@ impl Directory {
     /// // 'baz.rs' is a file and not a directory
     /// assert!(directory.find_directory(&unsound::path::new("foo/bar/baz.rs")).is_none());
     /// ```
-    pub fn find_directory(&self, path: &Path) -> Option<Self> {
+    pub fn find_directory(&self, path: Path) -> Option<Self> {
         self.sub_directories
-            .find_branch(&path.0)
+            .find_branch(path.0.clone())
             .cloned()
             .map(|tree| {
                 let (_, current) = path.split_last();
@@ -473,8 +473,8 @@ impl Directory {
     /// inclusive) and the `File` itself.
     ///
     /// This function is usually used for testing and demonstation purposes.
-    pub fn insert_file(&mut self, path: &Path, file: File) {
-        self.sub_directories.insert(&path.0, file)
+    pub fn insert_file(&mut self, path: Path, file: File) {
+        self.sub_directories.insert(path.0, file)
     }
 
     /// Insert files into a shared directory path.
@@ -489,7 +489,7 @@ impl Directory {
         match NonEmpty::from_slice(directory_path) {
             None => {
                 for (file_name, file) in files.into_iter() {
-                    self.insert_file(&Path::new(file_name), file)
+                    self.insert_file(Path::new(file_name), file)
                 }
             },
             Some(path) => {
@@ -498,7 +498,7 @@ impl Directory {
                     let mut file_path = Path(path.clone());
                     file_path.push(file_name);
 
-                    self.insert_file(&file_path, file)
+                    self.insert_file(file_path, file)
                 }
             },
         }
@@ -517,7 +517,7 @@ impl Directory {
                     file_path = Path::new(file_name);
                 }
 
-                directory.insert_file(&file_path, file)
+                directory.insert_file(file_path, file)
             }
         }
 

--- a/src/file_system/directory.rs
+++ b/src/file_system/directory.rs
@@ -283,13 +283,13 @@ impl Directory {
     /// let mut root = Directory::root();
     ///
     /// let main = File::new(b"println!(\"Hello, world!\")");
-    /// root.insert_file(&unsound::path::new("main.rs"), main.clone());
+    /// root.insert_file(unsound::path::new("main.rs"), main.clone());
     ///
     /// let lib = File::new(b"struct Hello(String)");
-    /// root.insert_file(&unsound::path::new("lib.rs"), lib.clone());
+    /// root.insert_file(unsound::path::new("lib.rs"), lib.clone());
     ///
     /// let test_mod = File::new(b"assert_eq!(1 + 1, 2);");
-    /// root.insert_file(&unsound::path::new("test/mod.rs"), test_mod.clone());
+    /// root.insert_file(unsound::path::new("test/mod.rs"), test_mod.clone());
     ///
     /// let mut root_iter = root.iter();
     ///
@@ -304,7 +304,7 @@ impl Directory {
     /// }));
     ///
     /// let mut test_dir = Directory::new(unsound::label::new("test"));
-    /// test_dir.insert_file(&unsound::path::new("mod.rs"), test_mod);
+    /// test_dir.insert_file(unsound::path::new("mod.rs"), test_mod);
     ///
     /// assert_eq!(root_iter.next(), Some(DirectoryContents::Directory(test_dir)));
     /// ```
@@ -350,16 +350,16 @@ impl Directory {
     /// let file = File::new(b"module Banana ...");
     ///
     /// let mut directory = Directory::root();
-    /// directory.insert_file(&unsound::path::new("foo/bar/baz.rs"), file.clone());
+    /// directory.insert_file(unsound::path::new("foo/bar/baz.rs"), file.clone());
     ///
     /// // The file is succesfully found
-    /// assert_eq!(directory.find_file(&unsound::path::new("foo/bar/baz.rs")), Some(file));
+    /// assert_eq!(directory.find_file(unsound::path::new("foo/bar/baz.rs")), Some(file));
     ///
     /// // We shouldn't be able to find a directory
-    /// assert_eq!(directory.find_file(&unsound::path::new("foo")), None);
+    /// assert_eq!(directory.find_file(unsound::path::new("foo")), None);
     ///
     /// // We shouldn't be able to find a file that doesn't exist
-    /// assert_eq!(directory.find_file(&unsound::path::new("foo/bar/qux.rs")), None);
+    /// assert_eq!(directory.find_file(unsound::path::new("foo/bar/qux.rs")), None);
     /// ```
     pub fn find_file(&self, path: Path) -> Option<File> {
         self.sub_directories.find_node(path.0).cloned()
@@ -386,19 +386,19 @@ impl Directory {
     /// let file = File::new(b"module Banana ...");
     ///
     /// let mut directory = Directory::root();
-    /// directory.insert_file(&unsound::path::new("foo/bar/baz.rs"), file.clone());
+    /// directory.insert_file(unsound::path::new("foo/bar/baz.rs"), file.clone());
     ///
     /// // Can find the first level
-    /// assert!(directory.find_directory(&unsound::path::new("foo")).is_some());
+    /// assert!(directory.find_directory(unsound::path::new("foo")).is_some());
     ///
     /// // Can find the second level
-    /// assert!(directory.find_directory(&unsound::path::new("foo/bar")).is_some());
+    /// assert!(directory.find_directory(unsound::path::new("foo/bar")).is_some());
     ///
     /// // Cannot find 'baz' since it does not exist
-    /// assert!(directory.find_directory(&unsound::path::new("foo/baz")).is_none());
+    /// assert!(directory.find_directory(unsound::path::new("foo/baz")).is_none());
     ///
     /// // 'baz.rs' is a file and not a directory
-    /// assert!(directory.find_directory(&unsound::path::new("foo/bar/baz.rs")).is_none());
+    /// assert!(directory.find_directory(unsound::path::new("foo/bar/baz.rs")).is_none());
     /// ```
     pub fn find_directory(&self, path: Path) -> Option<Self> {
         self.sub_directories
@@ -422,14 +422,14 @@ impl Directory {
     /// use radicle_surf::file_system::unsound;
     ///
     /// let mut root = Directory::root();
-    /// root.insert_file(&unsound::path::new("main.rs"), File::new(b"println!(\"Hello, world!\")"));
-    /// root.insert_file(&unsound::path::new("lib.rs"), File::new(b"struct Hello(String)"));
-    /// root.insert_file(&unsound::path::new("test/mod.rs"), File::new(b"assert_eq!(1 + 1, 2);"));
+    /// root.insert_file(unsound::path::new("main.rs"), File::new(b"println!(\"Hello, world!\")"));
+    /// root.insert_file(unsound::path::new("lib.rs"), File::new(b"struct Hello(String)"));
+    /// root.insert_file(unsound::path::new("test/mod.rs"), File::new(b"assert_eq!(1 + 1, 2);"));
     ///
     /// assert_eq!(root.current(), Label::root());
     ///
     /// let test = root.find_directory(
-    ///     &unsound::path::new("test")
+    ///     unsound::path::new("test")
     /// ).expect("Missing test directory");
     /// assert_eq!(test.current(), unsound::label::new("test"));
     /// ```
@@ -457,9 +457,9 @@ impl Directory {
     /// use radicle_surf::file_system::unsound;
     ///
     /// let mut root = Directory::root();
-    /// root.insert_file(&unsound::path::new("main.rs"), File::new(b"println!(\"Hello, world!\")"));
-    /// root.insert_file(&unsound::path::new("lib.rs"), File::new(b"struct Hello(String)"));
-    /// root.insert_file(&unsound::path::new("test/mod.rs"), File::new(b"assert_eq!(1 + 1, 2);"));
+    /// root.insert_file(unsound::path::new("main.rs"), File::new(b"println!(\"Hello, world!\")"));
+    /// root.insert_file(unsound::path::new("lib.rs"), File::new(b"struct Hello(String)"));
+    /// root.insert_file(unsound::path::new("test/mod.rs"), File::new(b"assert_eq!(1 + 1, 2);"));
     ///
     /// assert_eq!(root.size(), 66);
     /// ```
@@ -509,13 +509,13 @@ impl Directory {
 
         for (path, files) in files.into_iter() {
             for (file_name, file) in files.into_iter() {
-                let mut file_path = path.clone();
-
-                if path.is_root() {
-                    file_path.push(file_name);
+                let file_path = if path.is_root() {
+                    Path::new(file_name)
                 } else {
-                    file_path = Path::new(file_name);
-                }
+                    let mut new_path = path.clone();
+                    new_path.push(file_name);
+                    new_path
+                };
 
                 directory.insert_file(file_path, file)
             }
@@ -535,15 +535,15 @@ pub mod tests {
         fn root_files() {
             let mut directory = Directory::root();
             directory.insert_file(
-                &unsound::path::new("foo.hs"),
+                unsound::path::new("foo.hs"),
                 File::new(b"module BananaFoo ..."),
             );
             directory.insert_file(
-                &unsound::path::new("bar.hs"),
+                unsound::path::new("bar.hs"),
                 File::new(b"module BananaBar ..."),
             );
             directory.insert_file(
-                &unsound::path::new("baz.hs"),
+                unsound::path::new("baz.hs"),
                 File::new(b"module BananaBaz ..."),
             );
 
@@ -566,10 +566,10 @@ pub mod tests {
         fn in_root() {
             let file = File::new(b"module Banana ...");
             let mut directory = Directory::root();
-            directory.insert_file(&unsound::path::new("foo.hs"), file.clone());
+            directory.insert_file(unsound::path::new("foo.hs"), file.clone());
 
             assert_eq!(
-                directory.find_file(&unsound::path::new("foo.hs")),
+                directory.find_file(unsound::path::new("foo.hs")),
                 Some(file)
             );
         }
@@ -581,9 +581,9 @@ pub mod tests {
             let file = File::new(b"module Banana ...");
 
             let mut directory = Directory::root();
-            directory.insert_file(&unsound::path::new("foo.hs"), file);
+            directory.insert_file(unsound::path::new("foo.hs"), file);
 
-            assert_eq!(directory.find_file(&file_path), None)
+            assert_eq!(directory.find_file(file_path), None)
         }
     }
 
@@ -691,12 +691,16 @@ pub mod tests {
             for (directory_path, files) in new_directory_map {
                 for (file_name, _) in files.iter() {
                     let mut path = directory_path.clone();
-                    if directory.find_directory(&path).is_none() {
+                    if directory.find_directory(path.clone()).is_none() {
+                        eprintln!("Search Directory: {:#?}", directory);
+                        eprintln!("Path to find: {:#?}", path);
                         return false;
                     }
 
                     path.push(file_name.clone());
-                    if directory.find_file(&path).is_none() {
+                    if directory.find_file(path.clone()).is_none() {
+                        eprintln!("Search Directory: {:#?}", directory);
+                        eprintln!("Path to find: {:#?}", path);
                         return false;
                     }
                 }

--- a/src/file_system/path.rs
+++ b/src/file_system/path.rs
@@ -118,7 +118,7 @@ pub struct Path(pub NonEmpty<Label>);
 
 impl fmt::Display for Path {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (prefix, suffix) = self.split_last();
+        let (prefix, suffix) = self.clone().split_last();
         for p in prefix {
             write!(f, "{}/", p)?;
         }
@@ -317,8 +317,8 @@ impl Path {
     ///     (vec![unsound::label::new("foo"), unsound::label::new("bar")], unsound::label::new("baz"))
     /// );
     /// ```
-    pub fn split_last(&self) -> (Vec<Label>, Label) {
-        split_last(&self.0)
+    pub fn split_last(self) -> (Vec<Label>, Label) {
+        split_last(self.0)
     }
 
     /// Construct a `Path` given at least one [`Label`] followed by 0 or more

--- a/src/file_system/path.rs
+++ b/src/file_system/path.rs
@@ -207,13 +207,13 @@ impl Path {
     /// use std::convert::TryFrom;
     ///
     /// let mut path1 = unsound::path::new("foo/bar");
-    /// let mut path2 = unsound::path::new("baz/quux");
-    /// path1.append(&mut path2);
+    /// let path2 = unsound::path::new("baz/quux");
+    /// path1.append(path2);
     /// let expected = unsound::path::new("foo/bar/baz/quux");
     /// assert_eq!(path1, expected);
     /// ```
-    pub fn append(&mut self, path: &mut Self) {
-        let mut other = path.0.clone().into();
+    pub fn append(&mut self, path: Self) {
+        let mut other = path.0.into();
         self.0.append(&mut other)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! let memory = unsound::path::new("src/memory.rs");
 //!
 //! // And assert that we can find it!
-//! assert!(directory.find_file(&memory).is_some());
+//! assert!(directory.find_file(memory).is_some());
 //!
 //! let root_contents = directory.list_directory();
 //!
@@ -69,7 +69,7 @@
 //! ]);
 //!
 //! let src = directory
-//!     .find_directory(&Path::new(unsound::label::new("src")))
+//!     .find_directory(Path::new(unsound::label::new("src")))
 //!     .expect("failed to find src");
 //! let src_contents = src.list_directory();
 //!

--- a/src/nonempty.rs
+++ b/src/nonempty.rs
@@ -17,20 +17,17 @@
 
 use nonempty::NonEmpty;
 
-pub fn split_last<T>(non_empty: &NonEmpty<T>) -> (Vec<T>, T)
+pub fn split_last<T>(non_empty: NonEmpty<T>) -> (Vec<T>, T)
 where
-    T: Clone + Eq,
+    T: Eq,
 {
-    let (first, middle, last) = non_empty.split();
-
-    // first == last, so drop first
-    if first == last && middle.is_empty() {
-        (vec![], last.clone())
-    } else {
-        // Create the prefix vector
-        let mut vec = vec![first.clone()];
-        let mut middle = middle.to_vec();
-        vec.append(&mut middle);
-        (vec, last.clone())
+    let (head, mut tail) = non_empty.into();
+    let last = tail.pop();
+    match last {
+        None => (vec![], head),
+        Some(last) => {
+            tail.insert(0, head);
+            (tail, last)
+        },
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -173,7 +173,6 @@ impl<K, A> Tree<K, A> {
     {
         let (start, mut middle) = keys.into();
         let last = middle.pop();
-        // let (start, middle, last) = keys.split();
 
         match last {
             None => Tree::node(start, node),

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -72,9 +72,9 @@ impl<A> History<A> {
     }
 
     /// Apply a function from `A` to `B` over the `History`
-    pub fn map<F, B>(&self, f: F) -> History<B>
+    pub fn map<F, B>(self, f: F) -> History<B>
     where
-        F: Fn(&A) -> B,
+        F: FnMut(A) -> B,
     {
         History(self.0.map(f))
     }

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -303,7 +303,7 @@ impl<'repo> Repository {
                 };
 
                 file_histories.insert_with(
-                    &path.0,
+                    path.0,
                     NonEmpty::new(parent_commit.clone()),
                     |commits| commits.push(parent_commit),
                 );
@@ -880,10 +880,10 @@ impl Browser {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn last_commit(&self, path: &file_system::Path) -> Result<Option<Commit>, Error> {
+    pub fn last_commit(&self, path: file_system::Path) -> Result<Option<Commit>, Error> {
         let file_history = self.repository.file_history(self.get().first().clone())?;
 
-        Ok(file_history.find(&path.0).map(|tree| {
+        Ok(file_history.find(path.0).map(|tree| {
             tree.maximum_by(&|c: &NonEmpty<OrderedCommit>, d| c.first().compare_by_id(&d.first()))
                 .first()
                 .commit

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -47,7 +47,7 @@
 //!
 //! // find src directory in the Git directory and the in-memory directory
 //! let src_directory = directory
-//!     .find_directory(&Path::new(unsound::label::new("src")))
+//!     .find_directory(Path::new(unsound::label::new("src")))
 //!     .expect("failed to find src");
 //! let mut src_directory_contents = src_directory.list_directory();
 //! src_directory_contents.sort();
@@ -864,7 +864,7 @@ impl Browser {
     /// let expected_commit = Oid::from_str("d3464e33d75c75c99bfb90fa2e9d16efc0b7d0e3")?;
     ///
     /// let readme_last_commit = browser
-    ///     .last_commit(&Path::with_root(&[unsound::label::new("README.md")]))?
+    ///     .last_commit(Path::with_root(&[unsound::label::new("README.md")]))?
     ///     .map(|commit| commit.id);
     ///
     /// assert_eq!(readme_last_commit, Some(expected_commit));
@@ -872,7 +872,7 @@ impl Browser {
     /// let expected_commit = Oid::from_str("e24124b7538658220b5aaf3b6ef53758f0a106dc")?;
     ///
     /// let memory_last_commit = browser
-    ///     .last_commit(&Path::with_root(&[unsound::label::new("src"), unsound::label::new("memory.rs")]))?
+    ///     .last_commit(Path::with_root(&[unsound::label::new("src"), unsound::label::new("memory.rs")]))?
     ///     .map(|commit| commit.id);
     ///
     /// assert_eq!(memory_last_commit, Some(expected_commit));
@@ -1179,7 +1179,7 @@ mod tests {
 
             // memory.rs is commited later so it should not exist here.
             let memory_last_commit = browser
-                .last_commit(&Path::with_root(&[
+                .last_commit(Path::with_root(&[
                     unsound::label::new("src"),
                     unsound::label::new("memory.rs"),
                 ]))
@@ -1190,7 +1190,7 @@ mod tests {
 
             // README.md exists in this commit.
             let readme_last_commit = browser
-                .last_commit(&Path::with_root(&[unsound::label::new("README.md")]))
+                .last_commit(Path::with_root(&[unsound::label::new("README.md")]))
                 .expect("Failed to get last commit")
                 .map(|commit| commit.id);
 
@@ -1212,7 +1212,7 @@ mod tests {
                 Oid::from_str("f3a089488f4cfd1a240a9c01b3fcc4c34a4e97b2").unwrap();
 
             let folder_svelte = browser
-                .last_commit(&unsound::path::new("~/examples/Folder.svelte"))
+                .last_commit(unsound::path::new("~/examples/Folder.svelte"))
                 .expect("Failed to get last commit")
                 .map(|commit| commit.id);
 
@@ -1234,7 +1234,7 @@ mod tests {
                 Oid::from_str("2429f097664f9af0c5b7b389ab998b2199ffa977").unwrap();
 
             let nested_directory_tree_commit_id = browser
-                .last_commit(&unsound::path::new(
+                .last_commit(unsound::path::new(
                     "~/this/is/a/really/deeply/nested/directory/tree",
                 ))
                 .expect("Failed to get last commit")
@@ -1250,7 +1250,7 @@ mod tests {
             let browser = Browser::new(repo).expect("Could not initialise Browser");
 
             let root_last_commit_id = browser
-                .last_commit(&Path::root())
+                .last_commit(Path::root())
                 .expect("Failed to get last commit")
                 .map(|commit| commit.id);
 


### PR DESCRIPTION
Fixes #82 

Shift function parameters to take owned data rather than references when a `clone` is used in a function.