### PR TITLE
Bump git2 crate to latest version (0.13.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,13 @@ repository = "https://github.com/radicle-dev/radicle-surf"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-git2 = "0.12"
 thiserror = "1.0"
 nonempty = "0.4"
+
+[dependencies.git2]
+version = "0.13"
+default-features = false
+features = []
 
 [dev-dependencies]
 pretty_assertions = "0.6"


### PR DESCRIPTION
Also ensure openssl is not pulled in, as the openssl license is not compatible with the GPL. Note that the rust bindings crates are themselves MIT/Apache-2 licensed, but that does not seem to be legit, as they link against the native openssl library.