### PR TITLE
Commit Parents

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -259,7 +259,7 @@ impl<K, A> Tree<K, A> {
                     match sub_tree {
                         // Our sub-tree was a node.
                         SubTree::Node { key, value } => {
-                            std::mem::replace(key, head);
+                            let _ = std::mem::replace(key, head);
                             f(value);
                         },
                         SubTree::Branch { .. } => *sub_tree = SubTree::Node { key: head, value },

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -1126,6 +1126,21 @@ mod tests {
         }
 
         #[test]
+        fn commit_parents() -> Result<(), Error> {
+            let repo = Repository::new("./data/git-platinum")?;
+            let mut browser = Browser::new(repo)?;
+            browser.revspec("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
+            let commit = browser.history.first();
+
+            assert_eq!(
+                commit.parents,
+                vec![Oid::from_str("d6880352fc7fda8f521ae9b7357668b17bb5bad5")?]
+            );
+
+            Ok(())
+        }
+
+        #[test]
         fn commit_short() -> Result<(), Error> {
             let repo = Repository::new("./data/git-platinum")?;
             let mut browser = Browser::new(repo)?;

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -288,7 +288,7 @@ impl<'repo> Repository {
         let mut revwalk = self.0.revwalk()?;
 
         // Set the revwalk to the head commit
-        revwalk.push(commit_id.clone())?;
+        revwalk.push(*commit_id)?;
 
         for (id, commit_result) in revwalk.enumerate() {
             let parent_id = commit_result?;

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -16,7 +16,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::vcs::git::error::*;
-use git2;
 use std::{cmp::Ordering, convert::TryFrom, fmt, str};
 
 /// `Author` is the static information of a [`git2::Signature`].

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -67,6 +67,8 @@ pub struct Commit {
     pub message: String,
     /// The summary message of the commit.
     pub summary: String,
+    /// The parents of this commit.
+    pub parents: Vec<git2::Oid>,
 }
 
 impl<'repo> TryFrom<git2::Commit<'repo>> for Commit {
@@ -80,6 +82,7 @@ impl<'repo> TryFrom<git2::Commit<'repo>> for Commit {
         let message = str::from_utf8(message_raw)?.into();
         let summary_raw = commit.summary_bytes().expect("TODO");
         let summary = str::from_utf8(summary_raw)?.into();
+        let parents = commit.parent_ids().collect();
 
         Ok(Commit {
             id,
@@ -87,6 +90,7 @@ impl<'repo> TryFrom<git2::Commit<'repo>> for Commit {
             committer,
             message,
             summary,
+            parents,
         })
     }
 }


### PR DESCRIPTION
Fixes #96 

Add the commit identifiers to the `Commit` struct.