### PR TITLE
Broswer borrows Repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "1.0"
 nonempty = "0.4"
 
 [dependencies.git2]
-version = "0.13"
+version = "^0"
 default-features = false
 features = []
 

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -31,7 +31,7 @@ use radicle_surf::{
 fn main() {
     let options = get_options_or_exit();
     let repo = init_repository_or_exit(&options.path_to_repo);
-    let mut browser = init_browser_or_exit(repo);
+    let mut browser = git::Browser::new(&repo).expect("failed to create browser:");
 
     match options.head_revision {
         HeadRevision::HEAD => {
@@ -74,16 +74,6 @@ fn init_repository_or_exit(path_to_repo: &str) -> git::Repository {
         Ok(repo) => repo,
         Err(e) => {
             println!("Failed to create repository: {:?}", e);
-            std::process::exit(1);
-        },
-    }
-}
-
-fn init_browser_or_exit(repo: git::Repository) -> git::Browser {
-    match git::Browser::new(repo) {
-        Ok(browser) => browser,
-        Err(e) => {
-            println!("Failed to create browser: {:?}", e);
             std::process::exit(1);
         },
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! let repo = git::Repository::new("./data/git-platinum")?;
 //!
 //! // Here we initialise a new Broswer for a the git repo.
-//! let mut browser = git::Browser::new(repo)?;
+//! let mut browser = git::Browser::new(&repo)?;
 //!
 //! // Set the history to a particular commit
 //! let commit = git::Oid::from_str("80ded66281a4de2889cc07293a8f10947c6d57fe")?;

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -132,13 +132,13 @@ type Snapshot<A, Repo, Error> = Box<dyn Fn(&Repo, &History<A>) -> Result<Directo
 /// A `Browser` is a way of rendering a `History` into a
 /// `Directory` snapshot, and the current `History` it is
 /// viewing.
-pub struct Browser<Repo, A, Error> {
+pub struct Browser<'a, Repo, A, Error> {
     snapshot: Snapshot<A, Repo, Error>,
     history: History<A>,
-    repository: Repo,
+    repository: &'a Repo,
 }
 
-impl<Repo, A, Error> Browser<Repo, A, Error> {
+impl<'a, Repo, A, Error> Browser<'a, Repo, A, Error> {
     /// Get the current `History` the `Browser` is viewing.
     pub fn get(&self) -> History<A>
     where
@@ -176,7 +176,7 @@ impl<Repo, A, Error> Browser<Repo, A, Error> {
     }
 }
 
-impl<Repo, A, Error> VCS<A, Error> for Browser<Repo, A, Error>
+impl<'a, Repo, A, Error> VCS<A, Error> for Browser<'a, Repo, A, Error>
 where
     Repo: VCS<A, Error>,
 {

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -28,7 +28,7 @@
 //!
 //! // Pin the browser to a parituclar commit.
 //! let pin_commit = Oid::from_str("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
-//! let mut browser = Browser::new(repo)?;
+//! let mut browser = Browser::new(&repo)?;
 //! browser.commit(pin_commit)?;
 //!
 //! let directory = browser.get_directory()?;
@@ -420,9 +420,9 @@ impl std::fmt::Debug for Repository {
 /// A [`crate::vcs::Browser`] that uses [`Repository`] as the underlying
 /// repository backend, [`git2::Commit`] as the artifact, and [`Error`] for
 /// error reporting.
-pub type Browser = vcs::Browser<Repository, Commit, Error>;
+pub type Browser<'a> = vcs::Browser<'a, Repository, Commit, Error>;
 
-impl Browser {
+impl<'a> Browser<'a> {
     /// Create a new browser to interact with.
     ///
     /// It uses the current `HEAD` as the starting [`History`].
@@ -439,12 +439,12 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let browser = Browser::new(repo)?;
+    /// let browser = Browser::new(&repo)?;
     /// #
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new(repository: Repository) -> Result<Self, Error> {
+    pub fn new(repository: &'a Repository) -> Result<Self, Error> {
         let history = repository.head()?;
         let snapshot = Box::new(|repository: &Repository, history: &History| {
             let tree = Self::get_tree(&repository.0, history.0.first())?;
@@ -479,12 +479,15 @@ impl Browser {
     ///     .first()
     ///     .cloned()
     ///     .expect("failed to get first branch");
-    /// let browser = Browser::new_with_branch(repo, first_branch.name)?;
+    /// let browser = Browser::new_with_branch(&repo, first_branch.name)?;
     /// #
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new_with_branch(repository: Repository, branch_name: BranchName) -> Result<Self, Error> {
+    pub fn new_with_branch(
+        repository: &'a Repository,
+        branch_name: BranchName,
+    ) -> Result<Self, Error> {
         let history = repository.get_history(branch_name.name().to_string())?;
         let snapshot = Box::new(|repository: &Repository, history: &History| {
             let tree = Self::get_tree(&repository.0, history.0.first())?;
@@ -512,7 +515,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// // ensure we're at HEAD
     /// browser.head();
@@ -547,7 +550,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// // ensure we're on 'master'
     /// browser.branch(BranchName::new("master"));
@@ -569,7 +572,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     /// browser.branch(BranchName::new("origin/dev"))?;
     ///
     /// let directory = browser.get_directory()?;
@@ -617,7 +620,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// // Switch to "v0.3.0"
     /// browser.tag(TagName::new("v0.3.0"))?;
@@ -674,7 +677,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// // Set to the initial commit
     /// let commit = Oid::from_str("e24124b7538658220b5aaf3b6ef53758f0a106dc")?;
@@ -722,7 +725,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// browser.revspec("refs/remotes/origin/dev")?;
     ///
@@ -774,7 +777,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// let branches = browser.list_branches(None)?;
     ///
@@ -813,7 +816,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// let tags = browser.list_tags()?;
     ///
@@ -854,7 +857,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// // Clamp the Browser to a particular commit
     /// let commit = Oid::from_str("d6880352fc7fda8f521ae9b7357668b17bb5bad5")?;
@@ -907,7 +910,7 @@ impl Browser {
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let repo = Repository::new("./data/git-platinum")?;
-    /// let mut browser = Browser::new(repo)?;
+    /// let mut browser = Browser::new(&repo)?;
     ///
     /// let commit_with_signature_oid = Oid::from_str(
     ///     "e24124b7538658220b5aaf3b6ef53758f0a106dc"
@@ -1047,7 +1050,7 @@ mod tests {
     // An issue with submodules, see: https://github.com/radicle-dev/radicle-surf/issues/54
     fn test_submodule_failure() {
         let repo = Repository::new(".").unwrap();
-        let browser = Browser::new(repo).unwrap();
+        let browser = Browser::new(&repo).unwrap();
 
         browser.get_directory().unwrap();
     }
@@ -1070,7 +1073,7 @@ mod tests {
         #[test]
         fn _master() -> Result<(), Error> {
             let repo = Repository::new("./data/git-platinum")?;
-            let mut browser = Browser::new(repo)?;
+            let mut browser = Browser::new(&repo)?;
             browser.revspec("master")?;
 
             let commit1 = Oid::from_str("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
@@ -1109,7 +1112,7 @@ mod tests {
         #[test]
         fn commit() -> Result<(), Error> {
             let repo = Repository::new("./data/git-platinum")?;
-            let mut browser = Browser::new(repo)?;
+            let mut browser = Browser::new(&repo)?;
             browser.revspec("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
 
             let commit1 = Oid::from_str("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
@@ -1128,7 +1131,7 @@ mod tests {
         #[test]
         fn commit_parents() -> Result<(), Error> {
             let repo = Repository::new("./data/git-platinum")?;
-            let mut browser = Browser::new(repo)?;
+            let mut browser = Browser::new(&repo)?;
             browser.revspec("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
             let commit = browser.history.first();
 
@@ -1143,7 +1146,7 @@ mod tests {
         #[test]
         fn commit_short() -> Result<(), Error> {
             let repo = Repository::new("./data/git-platinum")?;
-            let mut browser = Browser::new(repo)?;
+            let mut browser = Browser::new(&repo)?;
             browser.revspec("3873745c8")?;
 
             let commit1 = Oid::from_str("3873745c8f6ffb45c990eb23b491d4b4b6182f95")?;
@@ -1162,7 +1165,7 @@ mod tests {
         #[test]
         fn tag() -> Result<(), Error> {
             let repo = Repository::new("./data/git-platinum")?;
-            let mut browser = Browser::new(repo)?;
+            let mut browser = Browser::new(&repo)?;
             browser.revspec("v0.2.0")?;
 
             let commit1 = Oid::from_str("2429f097664f9af0c5b7b389ab998b2199ffa977")?;
@@ -1183,7 +1186,7 @@ mod tests {
         fn readme_missing_and_memory() {
             let repo = Repository::new("./data/git-platinum")
                 .expect("Could not retrieve ./data/git-platinum as git repository");
-            let mut browser = Browser::new(repo).expect("Could not initialise Browser");
+            let mut browser = Browser::new(&repo).expect("Could not initialise Browser");
 
             // Set the browser history to the initial commit
             let commit = Oid::from_str("d3464e33d75c75c99bfb90fa2e9d16efc0b7d0e3")
@@ -1216,7 +1219,7 @@ mod tests {
         fn folder_svelte() {
             let repo = Repository::new("./data/git-platinum")
                 .expect("Could not retrieve ./data/git-platinum as git repository");
-            let mut browser = Browser::new(repo).expect("Could not initialise Browser");
+            let mut browser = Browser::new(&repo).expect("Could not initialise Browser");
 
             // Check that last commit is the actual last commit even if head commit differs.
             let commit = Oid::from_str("19bec071db6474af89c866a1bd0e4b1ff76e2b97")
@@ -1238,7 +1241,7 @@ mod tests {
         fn nest_directory() {
             let repo = Repository::new("./data/git-platinum")
                 .expect("Could not retrieve ./data/git-platinum as git repository");
-            let mut browser = Browser::new(repo).expect("Could not initialise Browser");
+            let mut browser = Browser::new(&repo).expect("Could not initialise Browser");
 
             // Check that last commit is the actual last commit even if head commit differs.
             let commit = Oid::from_str("19bec071db6474af89c866a1bd0e4b1ff76e2b97")
@@ -1262,7 +1265,7 @@ mod tests {
         fn root() {
             let repo = Repository::new("./data/git-platinum")
                 .expect("Could not retrieve ./data/git-platinum as git repository");
-            let browser = Browser::new(repo).expect("Could not initialise Browser");
+            let browser = Browser::new(&repo).expect("Could not initialise Browser");
 
             let root_last_commit_id = browser
                 .last_commit(Path::root())


### PR DESCRIPTION
Fixes #100 

Turns out this more straightforward than I thought. Obviously not backwards compatible, but moves towards thread-safe ops.