### PR TITLE
Specify only lower-bound on git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ thiserror = "1.0"
 nonempty = "0.4"
 
 [dependencies.git2]
-version = "^0"
+version = ">= 0.10"
 default-features = false
 features = []
 


### PR DESCRIPTION
While it is more common in the Rust ecosystem to specify (implicit)
"caret" requirements, it is usually a better choice in ecosystems which
tend to create large transitive dependency graphs to only specify a
lower bound in library dependencies. This way, upgrades by users are not
prohibited, and if something breaks, increases the likelihood for
maintenance contributions.