### PR TITLE
Optimise Commit History

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,8 @@ features = []
 [dev-dependencies]
 pretty_assertions = "0.6"
 proptest = "0.9"
+criterion = "0.3"
+
+[[bench]]
+name = "last_commit"
+harness = false

--- a/benches/last_commit.rs
+++ b/benches/last_commit.rs
@@ -1,0 +1,44 @@
+// This file is part of radicle-surf
+// <https://github.com/radicle-dev/radicle-surf>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use radicle_surf::{
+    file_system::{unsound, Path},
+    vcs::git::{Browser, Repository},
+};
+
+fn last_commit_comparison(c: &mut Criterion) {
+    let repo = Repository::new("./data/git-platinum")
+        .expect("Could not retrieve ./data/git-platinum as git repository");
+    let browser = Browser::new(&repo).expect("Could not initialise Browser");
+
+    let mut group = c.benchmark_group("Last Commit");
+    for path in [
+        Path::root(),
+        unsound::path::new("~/src/memory.rs"),
+        unsound::path::new("~/this/is/a/really/deeply/nested/directory/tree"),
+    ]
+    .iter()
+    {
+        group.bench_with_input(BenchmarkId::new("", path), path, |b, path| {
+            b.iter(|| browser.last_commit(path.clone()))
+        });
+    }
+}
+
+criterion_group!(benches, last_commit_comparison);
+criterion_main!(benches);

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,8 @@ stdenv.mkDerivation {
     name = "radicle-surf-dev";
     buildInputs = [
         (nixpkgs.rustChannelOf { rustToolChain = ./rust-toolchain; }).rust
+        # gnuplot for benchmark purposes
+        gnuplot
         pkgconfig
         zlib
         openssl

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -472,6 +472,7 @@ impl<K, A> Forest<K, A> {
         self.0.as_ref().and_then(|trees| trees.find_branch(keys))
     }
 
+    #[allow(dead_code)]
     /// Find a `SubTree` given a search path. If the path does not match
     /// it will return `None`.
     pub fn find(&self, keys: NonEmpty<K>) -> Option<&SubTree<K, A>>


### PR DESCRIPTION
We can pass a pathspec to a diff_tree_to_tree so that we can focus on a single file.
Since we're focusing on a single file it means we don't need to keep
track of the whole Tree and instead just return the Vec of commits.
The final optimisation is just exit early on last_commit because that's
all we care about.