### PR TITLE
Add conversion from &git2::Repository to RepositoryRef

### DIFF
--- a/src/vcs/git/repo.rs
+++ b/src/vcs/git/repo.rs
@@ -442,6 +442,12 @@ impl<'a> From<&'a Repository> for RepositoryRef<'a> {
     }
 }
 
+impl<'a> From<&'a git2::Repository> for RepositoryRef<'a> {
+    fn from(repo_ref: &'a git2::Repository) -> Self {
+        RepositoryRef { repo_ref }
+    }
+}
+
 impl vcs::GetVCS<Error> for Repository {
     type RepoId = String;
 


### PR DESCRIPTION
Otherwise, we need to own a `git2::Repository` in the first place. The ref version would not be needed then, as we can just borrow `surf::Repository`.