### PR TITLE
Use heads rather than remotes

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,5 +1,5 @@
 env:
-  DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-surf-build@sha256:24252f659024808246d8c4d674f19d8d923688cd5f857f4a607fe8dbf42c491c"
+  DOCKER_IMAGE: "gcr.io/opensourcecoin/radicle-surf-build@sha256:7d8c307ecc842440895af08ae035905302fc0327d335fd11361ea2e94b5e8797"
   DOCKER_FILE: .buildkite/docker/rust-nightly/Dockerfile
 
 steps:

--- a/build.rs
+++ b/build.rs
@@ -68,7 +68,7 @@ fn main() {
     let golden_status = setup_namespace(
         curr_dir,
         "refs/namespaces/golden/refs/heads/master",
-        "refs/heads/dev",
+        "refs/heads/master",
     );
     assert!(
         golden_status.success(),
@@ -78,7 +78,7 @@ fn main() {
     let silver_status = setup_namespace(
         curr_dir,
         "refs/namespaces/golden/refs/namespaces/silver/refs/heads/master",
-        "refs/remotes/origin/dev",
+        "refs/heads/dev",
     );
     assert!(
         silver_status.success(),


### PR DESCRIPTION
Bug fix

Using a remote wouldn't work downstream since the remotes wouldn't be set up when cargo grabs radicle-surf.