### PR TITLE
Fix is-binary was missing in 0.10 and 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1.3"
 thiserror = "1.0"
 
 [dependencies.git2]
-version = ">= 0.10"
+version = ">= 0.12"
 default-features = false
 features = []
 


### PR DESCRIPTION
It is needed for file diffing.