### PR TITLE
Make a best effort to try fetch a revspec in a namespace

### DIFF
--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -899,7 +899,7 @@ mod tests {
     #[cfg(test)]
     mod namespace {
         use super::*;
-        use pretty_assertions::assert_eq;
+        use pretty_assertions::{assert_eq, assert_ne};
 
         #[test]
         fn golden_namespace() -> Result<(), Error> {
@@ -941,7 +941,7 @@ mod tests {
                 silver_browser.which_namespace(),
                 Ok(Some(Namespace::from("golden/silver")))
             );
-            assert_eq!(history, silver_browser.history);
+            assert_ne!(history, silver_browser.history);
 
             let branches: Vec<Branch> = vec![Branch::local(BranchName::new(
                 "namespaces/golden/refs/namespaces/silver/refs/heads/master",

--- a/src/vcs/git/error.rs
+++ b/src/vcs/git/error.rs
@@ -21,7 +21,7 @@
 use crate::{
     diff,
     file_system,
-    vcs::git::object::{BranchName, TagName},
+    vcs::git::object::{BranchName, Namespace, TagName},
 };
 use std::str;
 use thiserror::Error;
@@ -44,6 +44,15 @@ pub enum Error {
     /// commit object.
     #[error("provided revspec '{rev}' could not be parsed into a git object")]
     RevParseFailure {
+        /// The provided revspec that failed to parse.
+        rev: String,
+    },
+    /// A `revspec` was provided that could not be found in the given
+    /// `namespace`.
+    #[error("provided revspec '{rev}' could not be parsed into a git object in the namespace '{namespace}'")]
+    NamespaceRevParseFailure {
+        /// The namespace we are in when attempting to fetch the `rev`.
+        namespace: Namespace,
         /// The provided revspec that failed to parse.
         rev: String,
     },

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::vcs::git::error::*;
+use crate::vcs::git::{error::*, repo::RepositoryRef};
 pub use git2::{BranchType, Oid};
 use std::{cmp::Ordering, convert::TryFrom, fmt, str};
 
@@ -358,8 +358,8 @@ impl RevObject {
     ///
     /// * `Error::Git` if the `revspec` provided fails to parse
     /// * `Error::RevParseFailure` if conversion to a target object fail.
-    pub fn from_revparse(repo: &git2::Repository, spec: &str) -> Result<Self, Error> {
-        let (object, optional_ref) = repo.revparse_ext(spec)?;
+    pub fn from_revparse<'a>(repo: &RepositoryRef<'a>, spec: &str) -> Result<Self, Error> {
+        let (object, optional_ref) = repo.repo_ref.revparse_ext(spec)?;
 
         let tag = object.into_tag().map(Tag::try_from);
         match tag {


### PR DESCRIPTION
Fixes #119 
Fixes #122 

This is a bit hairy, but there's no easy way to do a revparse within a namespace. We just make the best effort to try to guess what we're looking for. I guess that's what you get when you use strings everywhere :shrug: 

I also added `new_with_namespace` which will be needed for link to easily start a `Browser` in a namespace.