### PR TITLE
Fix Namespace Tags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -75,6 +75,26 @@ fn main() {
         "failed to set up 'golden' namespace"
     );
 
+    let golden_tag_v1 = setup_namespace(
+        curr_dir,
+        "refs/namespaces/golden/refs/tags/v0.1.0",
+        "refs/tags/v0.1.0",
+    );
+    assert!(
+        golden_tag_v1.success(),
+        "failed to set up 'golden' tag v0.1.0 namespace"
+    );
+
+    let golden_tag_v2 = setup_namespace(
+        curr_dir,
+        "refs/namespaces/golden/refs/tags/v0.2.0",
+        "refs/tags/v0.2.0",
+    );
+    assert!(
+        golden_tag_v2.success(),
+        "failed to set up 'golden' tag v0.2.0 namespace"
+    );
+
     let silver_status = setup_namespace(
         curr_dir,
         "refs/namespaces/golden/refs/namespaces/silver/refs/heads/master",

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -578,7 +578,7 @@ impl<'a> Browser<'a> {
     /// # Examples
     ///
     /// ```
-    /// use radicle_surf::vcs::git::{Browser, Oid, Repository, Tag, TagName};
+    /// use radicle_surf::vcs::git::{Browser, Namespace, Oid, Repository, Tag, TagName};
     /// # use std::error::Error;
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
@@ -612,6 +612,21 @@ impl<'a> Browser<'a> {
     ///         },
     ///     ]
     /// );
+    ///
+    /// // We can also switch namespaces and list the branches in that namespace.
+    /// let golden = browser.switch_namespace(&Namespace::from("golden"), "master")?;
+    ///
+    /// let branches = golden.list_tags()?;
+    /// assert_eq!(branches, vec![
+    ///     Tag::Light {
+    ///         id: Oid::from_str("d3464e33d75c75c99bfb90fa2e9d16efc0b7d0e3")?,
+    ///         name: TagName::new("namespaces/golden/refs/tags/v0.1.0"),
+    ///     },
+    ///     Tag::Light {
+    ///         id: Oid::from_str("2429f097664f9af0c5b7b389ab998b2199ffa977")?,
+    ///         name: TagName::new("namespaces/golden/refs/tags/v0.2.0")
+    ///     },
+    /// ]);
     /// #
     /// # Ok(())
     /// # }

--- a/src/vcs/git/object.rs
+++ b/src/vcs/git/object.rs
@@ -304,7 +304,7 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Tag {
     fn try_from(reference: git2::Reference) -> Result<Self, Self::Error> {
         let name = TagName::try_from(reference.shorthand_bytes())?;
 
-        if git_ext::is_tag(&reference) {
+        if !git_ext::is_tag(&reference) {
             return Err(Error::NotTag(name));
         }
 
@@ -447,12 +447,14 @@ impl TryFrom<&[u8]> for Namespace {
 mod git_ext {
     /// [`git2::Reference::is_tag`] just does a check for the prefix of `tags/`.
     /// This issue with that is, as soon as we're in 'namespaces' ref that
-    /// is a tag it will say that it's not a tag. So we work around that by
-    /// splitting the path and checking that a portion of it is a 'tags'
-    /// path.
+    /// is a tag it will say that it's not a tag. Instead we do a regex check on
+    /// `refs/tags/.*`.
     pub(super) fn is_tag(reference: &git2::Reference) -> bool {
-        let name = reference.name_bytes();
-        // split on '/' and check if a portion of the path is equal to 'tags'.
-        name.rsplit(|c| c == &218).any(|path| path == b"tags")
+        let re = regex::Regex::new(r"refs/tags/.*").unwrap();
+        // If we couldn't parse the name we say it's not a tag.
+        match reference.name() {
+            Some(name) => re.is_match(name),
+            None => false,
+        }
     }
 }


### PR DESCRIPTION
Fixes #128 

The check for `is_tag` in libgit is pretty rudimentary. It just checks whether the reference name is prefixed with `tags/`. This breaks when you introduce namespaces. So my fix (pronounced: workaround) is to split that ref name by `/` and check if a portion of it is equal to `tags`.