### PR TITLE
Don't rerun on git-platinum changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -105,6 +105,6 @@ fn main() {
         "failed to set up 'golden/silver' namespace"
     );
 
-    // Tell the build script that we should re-run this if git-platinum changes.
-    println!("cargo:rerun-if-changed=data/git-platinum");
+    // Tell the build script that we should re-run if this script changes.
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
The script checked for timestamp changes. The issue here is that every time we checkout dev then master, the directory time changes. Thus, end up in a loop for `cargo watch` and downstream dependents always have to re-compile.