### PR TITLE
Remote Branches

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,7 @@ fn checkout(curr_dir: &Path, branch: &str) -> ExitStatus {
         .unwrap_or_else(|_| panic!("Failed to execute `git submodule update {}`", git_checkout))
 }
 
-fn setup_namespace(curr_dir: &Path, namespace: &str, target: &str) -> ExitStatus {
+fn update_ref(curr_dir: &Path, namespace: &str, target: &str) -> ExitStatus {
     let namespace = format!("git update-ref {} {}", namespace, target);
     Command::new("git")
         .arg("submodule")
@@ -65,55 +65,39 @@ fn setup_fixtures() {
     let master_status = checkout(curr_dir, "master");
     assert!(master_status.success(), "failed to checkout master");
 
-    let golden_master = setup_namespace(
-        curr_dir,
-        "refs/namespaces/golden/refs/heads/master",
-        "refs/heads/master",
-    );
-    assert!(
-        golden_master.success(),
-        "failed to set up 'golden' master branch namespace"
-    );
-
-    let golden_banana = setup_namespace(
-        curr_dir,
-        "refs/namespaces/golden/refs/heads/banana",
-        "refs/heads/dev",
-    );
-    assert!(
-        golden_banana.success(),
-        "failed to set up 'golden' banana branch in namespace"
-    );
-
-    let golden_tag_v1 = setup_namespace(
-        curr_dir,
-        "refs/namespaces/golden/refs/tags/v0.1.0",
-        "refs/tags/v0.1.0",
-    );
-    assert!(
-        golden_tag_v1.success(),
-        "failed to set up 'golden' tag v0.1.0 namespace"
-    );
-
-    let golden_tag_v2 = setup_namespace(
-        curr_dir,
-        "refs/namespaces/golden/refs/tags/v0.2.0",
-        "refs/tags/v0.2.0",
-    );
-    assert!(
-        golden_tag_v2.success(),
-        "failed to set up 'golden' tag v0.2.0 namespace"
-    );
-
-    let silver_status = setup_namespace(
-        curr_dir,
-        "refs/namespaces/golden/refs/namespaces/silver/refs/heads/master",
-        "refs/heads/dev",
-    );
-    assert!(
-        silver_status.success(),
-        "failed to set up 'golden/silver' namespace"
-    );
+    for (new_rev, rev) in [
+        (
+            "refs/namespaces/golden/refs/heads/master",
+            "refs/heads/master",
+        ),
+        ("refs/namespaces/golden/refs/heads/banana", "refs/heads/dev"),
+        (
+            "refs/namespaces/golden/refs/tags/v0.1.0",
+            "refs/tags/v0.1.0",
+        ),
+        (
+            "refs/namespaces/golden/refs/tags/v0.2.0",
+            "refs/tags/v0.2.0",
+        ),
+        (
+            "refs/namespaces/golden/refs/namespaces/silver/refs/heads/master",
+            "refs/heads/dev",
+        ),
+        (
+            "refs/remotes/banana/pineapple",
+            "refs/remotes/origin/master",
+        ),
+    ]
+    .iter()
+    {
+        let update_rev = update_ref(curr_dir, new_rev, rev);
+        assert!(
+            update_rev.success(),
+            "failed to set up '{} -> {}'",
+            new_rev,
+            rev
+        );
+    }
 }
 
 fn main() {

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -519,14 +519,29 @@ impl<'a> Browser<'a> {
     /// // 'master' exists in the list of branches
     /// assert!(branches.contains(&Branch::local(BranchName::new("master"))));
     ///
-    /// // Filter the branches by `Remote`.
-    /// let mut branches = browser.list_branches(Some(BranchType::Remote))?;
+    /// // Filter the branches by `Remote` 'origin'.
+    /// let mut branches = browser.list_branches(Some(BranchType::Remote {
+    ///     name: Some("origin".to_string())
+    /// }))?;
     /// branches.sort();
     ///
     /// assert_eq!(branches, vec![
-    ///     Branch::remote(BranchName::new("origin/HEAD")),
-    ///     Branch::remote(BranchName::new("origin/dev")),
-    ///     Branch::remote(BranchName::new("origin/master")),
+    ///     Branch::remote(BranchName::new("HEAD"), "origin".to_string()),
+    ///     Branch::remote(BranchName::new("dev"), "origin".to_string()),
+    ///     Branch::remote(BranchName::new("master"), "origin".to_string()),
+    /// ]);
+    ///
+    /// // Filter the branches by all `Remote`s.
+    /// let mut branches = browser.list_branches(Some(BranchType::Remote {
+    ///     name: None
+    /// }))?;
+    /// branches.sort();
+    ///
+    /// assert_eq!(branches, vec![
+    ///     Branch::remote(BranchName::new("HEAD"), "origin".to_string()),
+    ///     Branch::remote(BranchName::new("dev"), "origin".to_string()),
+    ///     Branch::remote(BranchName::new("master"), "origin".to_string()),
+    ///     Branch::remote(BranchName::new("pineapple"), "banana".to_string()),
     /// ]);
     ///
     /// // We can also switch namespaces and list the branches in that namespace.
@@ -1469,6 +1484,7 @@ mod tests {
     #[cfg(test)]
     mod threading {
         use crate::vcs::git::*;
+        use pretty_assertions::assert_eq;
         use std::sync::{Mutex, MutexGuard};
 
         #[test]
@@ -1482,11 +1498,12 @@ mod tests {
             assert_eq!(
                 branches,
                 vec![
+                    Branch::remote(BranchName::new("HEAD"), "origin".to_string()),
+                    Branch::remote(BranchName::new("dev"), "origin".to_string()),
                     Branch::local(BranchName::new("dev")),
+                    Branch::remote(BranchName::new("master"), "origin".to_string()),
                     Branch::local(BranchName::new("master")),
-                    Branch::remote(BranchName::new("origin/HEAD")),
-                    Branch::remote(BranchName::new("origin/dev")),
-                    Branch::remote(BranchName::new("origin/master")),
+                    Branch::remote(BranchName::new("pineapple"), "banana".to_string()),
                 ]
             );
 

--- a/src/vcs/git/error.rs
+++ b/src/vcs/git/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
     /// or that a tag or commit was provided by accident.
     #[error("provided branch name does not exist: {0}")]
     NotBranch(BranchName),
+    /// We tried to convert a name into its remote and branch name parts.
+    #[error("could not parse '{0}' into a remote name and branch name")]
+    ParseRemoteBranch(BranchName),
     /// The user tried to fetch a tag, but the name provided does not
     /// exist as a tag. This could mean that the tag does not exist
     /// or that a branch or commit was provided by accident.

--- a/src/vcs/git/repo.rs
+++ b/src/vcs/git/repo.rs
@@ -22,13 +22,13 @@ use crate::{
     vcs::{
         git::{
             error::*,
-            object::{Branch, Commit, Namespace, RevObject, Signature, Tag},
+            object::{Branch, BranchType, Commit, Namespace, RevObject, Signature, Tag},
             reference::{glob::RefGlob, Ref},
         },
         VCS,
     },
 };
-use git2::{BranchType, Oid};
+use git2::Oid;
 use nonempty::NonEmpty;
 use std::{collections::HashSet, convert::TryFrom, str};
 
@@ -87,7 +87,7 @@ impl<'a> RepositoryRef<'a> {
     ///
     /// * [`Error::Git`]
     pub fn list_branches(&self, filter: Option<BranchType>) -> Result<Vec<Branch>, Error> {
-        let ref_glob = filter.map_or(RefGlob::Branch, RefGlob::from_branch_type);
+        let ref_glob = filter.map_or(RefGlob::Branch, RefGlob::from);
 
         ref_glob
             .references(&self)?


### PR DESCRIPTION
Minimal change so that we can filter by a remote name when listing branches.

I added to the `build.rs` file so that we can add a new ref under `remotes/banana/pineapple` and cleaned up this repeated logic.