### PR TITLE
Remove one level of refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "radicle-surf"
 description = "A code surfing library for VCS file systems"
 readme = "README.md"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 homepage = "https://github.com/radicle-dev/radicle-surf"

--- a/build.rs
+++ b/build.rs
@@ -80,7 +80,7 @@ fn setup_fixtures() {
             "refs/tags/v0.2.0",
         ),
         (
-            "refs/namespaces/golden/refs/remotes/kickflip/refs/heads/heelflip",
+            "refs/namespaces/golden/refs/remotes/kickflip/heads/heelflip",
             "refs/heads/dev",
         ),
         (

--- a/src/vcs/git/ext.rs
+++ b/src/vcs/git/ext.rs
@@ -18,10 +18,8 @@
 /// Try to strip any refs/namespaces, refs/heads, refs/remotes, and
 /// refs/tags. If this fails we return the original string.
 pub fn try_extract_refname(spec: &str) -> Result<String, String> {
-    let re = regex::Regex::new(
-        r"(refs/namespaces/.*?/)*(refs/remotes/(.*?)/)?(refs/heads/|refs/tags/)?(.*)",
-    )
-    .unwrap();
+    let re = regex::Regex::new(r"(refs/namespaces/.*?/)*refs/(remotes/(.*?)/)?(heads/|tags/)?(.*)")
+        .unwrap();
 
     re.captures(spec)
         .and_then(|c| {
@@ -106,7 +104,7 @@ mod tests {
         );
 
         assert_eq!(
-            try_extract_refname("refs/namespaces/golden/refs/remotes/kickflip/refs/heads/heelflip"),
+            try_extract_refname("refs/namespaces/golden/refs/remotes/kickflip/heads/heelflip"),
             Ok("kickflip/heelflip".to_string())
         );
     }


### PR DESCRIPTION
When we dive into a namespace that has a remote we originally expected
the heads to be under refs, i.e. `remotes/<remote>/refs/heads/*`. This
`refs` isn't needed and it should be `remotes/<remote>/heads/*`.