### PR TITLE
Remote revisions

### DIFF
--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -879,7 +879,10 @@ impl<'a> Browser<'a> {
     /// let branches = browser.revision_branches(Oid::from_str("27acd68c7504755aa11023300890bb85bbd69d45")?)?;
     /// assert_eq!(
     ///     branches,
-    ///     vec![Branch::local("dev")]
+    ///     vec![
+    ///         Branch::local("dev"),
+    ///         Branch::remote("dev", "origin"),
+    ///     ]
     /// );
     ///
     /// // TODO(finto): I worry that this test will fail as other branches get added
@@ -889,6 +892,10 @@ impl<'a> Browser<'a> {
     ///     vec![
     ///         Branch::local("dev"),
     ///         Branch::local("master"),
+    ///         Branch::remote("pineapple", "banana"),
+    ///         Branch::remote("HEAD", "origin"),
+    ///         Branch::remote("dev", "origin"),
+    ///         Branch::remote("master", "origin"),
     ///     ]
     /// );
     ///
@@ -898,7 +905,10 @@ impl<'a> Browser<'a> {
     /// let branches = golden_browser.revision_branches(Oid::from_str("27acd68c7504755aa11023300890bb85bbd69d45")?)?;
     /// assert_eq!(
     ///     branches,
-    ///     vec![Branch::local("banana")]
+    ///     vec![
+    ///         Branch::local("banana"),
+    ///         Branch::remote("heelflip", "kickflip"),
+    ///     ]
     /// );
     /// #
     /// # Ok(())

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -886,16 +886,17 @@ impl<'a> Browser<'a> {
     /// );
     ///
     /// // TODO(finto): I worry that this test will fail as other branches get added
-    /// let branches = browser.revision_branches(Oid::from_str("1820cb07c1a890016ca5578aa652fd4d4c38967e")?)?;
+    /// let mut branches = browser.revision_branches(Oid::from_str("1820cb07c1a890016ca5578aa652fd4d4c38967e")?)?;
+    /// branches.sort();
     /// assert_eq!(
     ///     branches,
     ///     vec![
-    ///         Branch::local("dev"),
-    ///         Branch::local("master"),
-    ///         Branch::remote("pineapple", "banana"),
     ///         Branch::remote("HEAD", "origin"),
+    ///         Branch::local("dev"),
     ///         Branch::remote("dev", "origin"),
+    ///         Branch::local("master"),
     ///         Branch::remote("master", "origin"),
+    ///         Branch::remote("pineapple", "banana"),
     ///     ]
     /// );
     ///

--- a/src/vcs/git/repo.rs
+++ b/src/vcs/git/repo.rs
@@ -259,11 +259,13 @@ impl<'a> RepositoryRef<'a> {
     }
 
     pub(crate) fn revision_branches(&self, oid: &Oid) -> Result<Vec<Branch>, Error> {
-        let references = RefGlob::LocalBranch.references(self)?;
+        let local = RefGlob::LocalBranch.references(self)?;
+        let remote = RefGlob::RemoteBranch { remote: None }.references(self)?;
+        let mut references = local.iter().chain(remote.iter());
 
         let mut contained_branches = vec![];
 
-        references.iter().try_for_each(|reference| {
+        references.try_for_each(|reference| {
             let reference = reference?;
             self.reachable_from(&reference, &oid).and_then(|contains| {
                 if contains {


### PR DESCRIPTION
Fixes #153 

The idea here is that we were only searching local branches for a particular commit. Will allow us to look at remote branches as well which is needed in Upstream since the only branches that exist after a new clone are remote branches.