### PR TITLE
Use git ext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "radicle-surf"
 description = "A code surfing library for VCS file systems"
 readme = "README.md"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 homepage = "https://github.com/radicle-dev/radicle-surf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,17 @@ serde = { features = ["serde_derive"], optional = true, version = "1" }
 thiserror = "1.0"
 
 [dependencies.git2]
-version = ">= 0.12"
+version = "0.13"
 default-features = false
 features = []
+
+[dependencies.radicle-git-ext]
+git = "https://github.com/radicle-dev/radicle-link.git"
+rev = "1a7c3f48dc156c14166764b2e3f862b867cc2812"
+
+[dependencies.radicle-macros]
+git = "https://github.com/radicle-dev/radicle-link.git"
+rev = "1a7c3f48dc156c14166764b2e3f862b867cc2812"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/benches/last_commit.rs
+++ b/benches/last_commit.rs
@@ -16,16 +16,18 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
 use radicle_surf::{
     file_system::{unsound, Path},
+    reflike,
     vcs::git::{Branch, Browser, Repository},
 };
 
 fn last_commit_comparison(c: &mut Criterion) {
     let repo = Repository::new("./data/git-platinum")
         .expect("Could not retrieve ./data/git-platinum as git repository");
-    let browser =
-        Browser::new(&repo, Branch::local("master")).expect("Could not initialise Browser");
+    let browser = Browser::new(&repo, Branch::local(reflike!("master")))
+        .expect("Could not initialise Browser");
 
     let mut group = c.benchmark_group("Last Commit");
     for path in [

--- a/deny.toml
+++ b/deny.toml
@@ -210,5 +210,6 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
+    "https://github.com/radicle-dev/radicle-link",
 ]
 

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -22,6 +22,7 @@ use std::{env::Args, time::Instant};
 use git2::Oid;
 use nonempty::NonEmpty;
 
+use radicle_macros::reflike;
 use radicle_surf::{
     diff::Diff,
     file_system::Directory,
@@ -31,8 +32,8 @@ use radicle_surf::{
 fn main() {
     let options = get_options_or_exit();
     let repo = init_repository_or_exit(&options.path_to_repo);
-    let mut browser =
-        git::Browser::new(&repo, git::Branch::local("master")).expect("failed to create browser:");
+    let mut browser = git::Browser::new(&repo, git::Branch::local(reflike!("master")))
+        .expect("failed to create browser:");
 
     match options.head_revision {
         HeadRevision::HEAD => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,14 @@
 //! Let's start surfing (and apologies for the `expect`s):
 //!
 //! ```
-//! use radicle_surf::vcs::git;
+//! use std::str::FromStr;
+//!
 //! use radicle_surf::file_system::{Label, Path, SystemType};
 //! use radicle_surf::file_system::unsound;
+//! use radicle_surf::reflike;
+//! use radicle_surf::vcs::git;
+//!
 //! use pretty_assertions::assert_eq;
-//! use std::str::FromStr;
 //! # use std::error::Error;
 //!
 //! # fn main() -> Result<(), Box<dyn Error>> {
@@ -41,7 +44,7 @@
 //! let repo = git::Repository::new("./data/git-platinum")?;
 //!
 //! // Here we initialise a new Broswer for a the git repo.
-//! let mut browser = git::Browser::new(&repo, git::Branch::local("master"))?;
+//! let mut browser = git::Browser::new(&repo, git::Branch::local(reflike!("master")))?;
 //!
 //! // Set the history to a particular commit
 //! let commit = git::Oid::from_str("80ded66281a4de2889cc07293a8f10947c6d57fe")?;
@@ -92,5 +95,9 @@ mod tree;
 
 pub use crate::vcs::git;
 
+pub use radicle_git_ext::{OneLevel, Qualified, RefLike};
+pub use radicle_macros::{reflike, refspec_pattern};
+
+#[cfg(test)]
 #[macro_use]
-extern crate lazy_static;
+extern crate radicle_macros;

--- a/src/vcs/git/branch.rs
+++ b/src/vcs/git/branch.rs
@@ -15,8 +15,30 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::vcs::git::{self, error::Error, ext, reference::Ref};
-use std::{cmp::Ordering, convert::TryFrom, fmt, str};
+use std::{cmp::Ordering, convert::TryFrom};
+
+use radicle_git_ext::{self as ext, OneLevel, Qualified, RefLike};
+
+use crate::vcs::git::{self, reference::Ref};
+
+/// An error occurred attempting to parse a [`Branch`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The [`git::Reference`] name was invalid.
+    #[error(transparent)]
+    Name(#[from] ext::name::Error),
+    /// We tried to convert a name into its remote and branch name parts.
+    #[error("no remote could be determined for `{0}`")]
+    NoRemote(RefLike),
+    /// The user tried to fetch a branch, but the name provided does not
+    /// exist as a branch. This could mean that the branch does not exist
+    /// or that a tag or commit was provided by accident.
+    #[error("the reference `{0}` is not a branch")]
+    NotBranch(RefLike),
+    /// The [`git::Reference`] could not successfully remove the namespace.
+    #[error(transparent)]
+    Strip(#[from] ext::name::StripPrefixError),
+}
 
 /// The branch type we want to filter on.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -27,7 +49,7 @@ pub enum BranchType {
     /// provided, otherwise `refs/remotes/**/*`.
     Remote {
         /// Name of the remote.
-        name: Option<String>,
+        name: Option<RefLike>, // TODO(finto): Needs to be Either<RefspecPattern, RefLike>
     },
 }
 
@@ -49,42 +71,6 @@ impl From<git2::BranchType> for BranchType {
     }
 }
 
-/// A newtype wrapper over `String` to separate out the fact that a caller wants
-/// to fetch a branch.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct BranchName(pub(crate) String);
-
-impl fmt::Display for BranchName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl TryFrom<&[u8]> for BranchName {
-    type Error = str::Utf8Error;
-
-    fn try_from(name: &[u8]) -> Result<Self, Self::Error> {
-        let name = str::from_utf8(name)?;
-        let short_name = match git::ext::try_extract_refname(name) {
-            Ok(stripped) => stripped,
-            Err(original) => original,
-        };
-        Ok(Self(short_name))
-    }
-}
-
-impl BranchName {
-    /// Create a new `BranchName`.
-    pub fn new(name: &str) -> Self {
-        Self(name.into())
-    }
-
-    /// Access the string value of the `BranchName`.
-    pub fn name(&self) -> &str {
-        &self.0
-    }
-}
-
 /// The static information of a `git2::Branch`.
 ///
 /// **Note**: The `PartialOrd` and `Ord` implementations compare on `BranchName`
@@ -92,7 +78,7 @@ impl BranchName {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Branch {
     /// Name identifier of the `Branch`.
-    pub name: BranchName,
+    pub name: OneLevel,
     /// Whether the `Branch` is `Remote` or `Local`.
     pub locality: BranchType,
 }
@@ -112,10 +98,12 @@ impl Ord for Branch {
 impl From<Branch> for Ref {
     fn from(other: Branch) -> Self {
         match other.locality {
-            BranchType::Local => Self::LocalBranch { name: other.name },
+            BranchType::Local => Self::LocalBranch {
+                name: Qualified::from(other.name),
+            },
             BranchType::Remote { name } => Self::RemoteBranch {
                 name: other.name,
-                remote: name.unwrap_or_else(|| "**".to_string()),
+                remote: name.unwrap_or_else(|| todo!()), // "**".to_string()),
             },
         }
     }
@@ -123,31 +111,31 @@ impl From<Branch> for Ref {
 
 impl Branch {
     /// Helper to create a remote `Branch` with a name
-    pub fn remote(name: &str, remote: &str) -> Self {
+    pub fn remote(name: impl Into<OneLevel>, remote: impl Into<RefLike>) -> Self {
         Self {
-            name: BranchName(name.to_string()),
+            name: name.into(),
             locality: BranchType::Remote {
-                name: Some(remote.to_string()),
+                name: Some(remote.into()),
             },
         }
     }
 
     /// Helper to create a remote `Branch` with a name
-    pub fn local(name: &str) -> Self {
+    pub fn local(name: impl Into<OneLevel>) -> Self {
         Self {
-            name: BranchName(name.to_string()),
+            name: name.into(),
             locality: BranchType::Local,
         }
     }
 
     /// Get the name of the `Branch`.
-    pub fn name(&self) -> String {
-        let branch_name = self.name.0.clone();
+    pub fn name(&self) -> OneLevel {
+        let branch_name = self.name.clone();
         match self.locality {
             BranchType::Local => branch_name,
             BranchType::Remote { ref name } => match name {
                 None => branch_name,
-                Some(remote_name) => format!("{}/{}", remote_name, branch_name),
+                Some(remote_name) => OneLevel::from(remote_name.join(branch_name)),
             },
         }
     }
@@ -157,10 +145,10 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Branch {
     type Error = Error;
 
     fn try_from(reference: git2::Reference) -> Result<Self, Self::Error> {
-        let is_remote = ext::is_remote(&reference);
+        let is_remote = git::ext::is_remote(&reference);
         let is_tag = reference.is_tag();
         let is_note = reference.is_note();
-        let name = BranchName::try_from(reference.name_bytes())?;
+        let name = git::ext::remove_namespace(RefLike::try_from(reference.name_bytes())?)?;
 
         // Best effort to not return tags or notes. Assuming everything after that is a
         // branch.
@@ -169,24 +157,44 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Branch {
         }
 
         if is_remote {
-            let mut split = name.0.split('/');
-            let remote_name = split
-                .next()
-                .ok_or_else(|| Error::ParseRemoteBranch(name.clone()))?;
-            let name = split
-                .next()
-                .ok_or_else(|| Error::ParseRemoteBranch(name.clone()))?;
+            let (remote, name) = extract_remote(name.clone())?.ok_or(Error::NoRemote(name))?;
             Ok(Self {
-                name: BranchName(name.to_string()),
-                locality: BranchType::Remote {
-                    name: Some(remote_name.to_string()),
-                },
+                name,
+                locality: BranchType::Remote { name: Some(remote) },
             })
         } else {
             Ok(Self {
-                name,
+                name: OneLevel::from(name),
                 locality: BranchType::Local,
             })
         }
     }
+}
+
+fn extract_remote(reflike: RefLike) -> Result<Option<(RefLike, OneLevel)>, Error> {
+    if !reflike.starts_with("refs/remotes/") {
+        return Ok(None);
+    }
+
+    let suffix = reflike.strip_prefix("refs/remotes/")?;
+    let mut components = suffix.components();
+    let remote = components
+        .next()
+        .ok_or(Error::NoRemote(reflike))
+        .and_then(|c| {
+            RefLike::try_from(
+                c.as_os_str()
+                    .to_str()
+                    .expect("reflike components are valid os str"),
+            )
+            .map_err(Error::from)
+        })?;
+
+    let name = RefLike::try_from(components.as_path())?;
+    let name = if name.starts_with("heads/") {
+        name.strip_prefix("heads/")?
+    } else {
+        name
+    };
+    Ok(Some((remote, name.into())))
 }

--- a/src/vcs/git/error.rs
+++ b/src/vcs/git/error.rs
@@ -18,31 +18,25 @@
 //! Collection of errors and helper instances that can occur when performing
 //! operations from [`crate::vcs::git`].
 
-use crate::{
-    diff,
-    file_system,
-    vcs::git::{BranchName, Namespace, TagName},
-};
 use std::str;
 use thiserror::Error;
 
+use crate::{
+    diff,
+    file_system,
+    vcs::git::{self, Namespace},
+};
+
 /// Enumeration of errors that can occur in operations from [`crate::vcs::git`].
-#[derive(Debug, PartialEq, Error)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
-    /// The user tried to fetch a branch, but the name provided does not
-    /// exist as a branch. This could mean that the branch does not exist
-    /// or that a tag or commit was provided by accident.
-    #[error("provided branch name does not exist: {0}")]
-    NotBranch(BranchName),
-    /// We tried to convert a name into its remote and branch name parts.
-    #[error("could not parse '{0}' into a remote name and branch name")]
-    ParseRemoteBranch(BranchName),
-    /// The user tried to fetch a tag, but the name provided does not
-    /// exist as a tag. This could mean that the tag does not exist
-    /// or that a branch or commit was provided by accident.
-    #[error("provided tag name does not exist: {0}")]
-    NotTag(TagName),
+    /// An error occurred while attempting to parse a [`git::branch::Branch`].
+    #[error(transparent)]
+    Branch(#[from] git::branch::Error),
+    /// An error occurred while attempting to parse a [`git::branch::Tag`].
+    #[error(transparent)]
+    Tag(#[from] git::tag::Error),
     /// A `revspec` was provided that could not be parsed into a branch, tag, or
     /// commit object.
     #[error("provided revspec '{rev}' could not be parsed into a git object")]

--- a/src/vcs/git/namespace.rs
+++ b/src/vcs/git/namespace.rs
@@ -15,10 +15,11 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::vcs::git::error::Error;
 pub use git2::Oid;
 use nonempty::NonEmpty;
 use std::{convert::TryFrom, fmt, str};
+
+use crate::vcs::git::error::Error;
 
 /// A `Namespace` value allows us to switch the git namespace of
 /// [`super::Browser`].

--- a/src/vcs/git/reference/glob.rs
+++ b/src/vcs/git/reference/glob.rs
@@ -15,9 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::vcs::git::{error, repo::RepositoryRef, BranchType};
 use either::Either;
 use std::fmt;
+
+use radicle_git_ext as ext;
+
+use crate::vcs::git::{error, repo::RepositoryRef, BranchType};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RefGlob {
@@ -34,7 +37,7 @@ pub enum RefGlob {
     RemoteBranch {
         /// If `remote` is `None` then the `**` wildcard will be used, otherwise
         /// the provided remote name will be used.
-        remote: Option<String>,
+        remote: Option<ext::RefLike>,
     },
     /// When calling [`RefGlob::references`] this will return the references via
     /// the globs `refs/heads/*` and `refs/remotes/**/*`.

--- a/src/vcs/git/tag.rs
+++ b/src/vcs/git/tag.rs
@@ -15,50 +15,33 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::vcs::git::{self, error::Error, reference::Ref, Author};
 use git2::Oid;
-use std::{convert::TryFrom, fmt, str};
+use std::{convert::TryFrom, str};
 
-/// A newtype wrapper over `String` to separate out the fact that a caller wants
-/// to fetch a tag.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct TagName(String);
+use radicle_git_ext::{self as ext, OneLevel, RefLike};
 
-impl fmt::Display for TagName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
+use crate::vcs::git::{self, Author};
 
-impl TryFrom<&[u8]> for TagName {
-    type Error = str::Utf8Error;
-
-    fn try_from(name: &[u8]) -> Result<Self, Self::Error> {
-        let name = str::from_utf8(name)?;
-        let short_name = match git::ext::try_extract_refname(name) {
-            Ok(stripped) => stripped,
-            Err(original) => original,
-        };
-        Ok(Self(short_name))
-    }
-}
-
-impl From<TagName> for Ref {
-    fn from(other: TagName) -> Self {
-        Self::Tag { name: other }
-    }
-}
-
-impl TagName {
-    /// Create a new `TagName`.
-    pub fn new(name: &str) -> Self {
-        TagName(name.into())
-    }
-
-    /// Access the string value of the `TagName`.
-    pub fn name(&self) -> &str {
-        &self.0
-    }
+/// An error occurred attempting to parse a [`Tag`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An unexpected [`git2:::Error`] occurred.
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+    /// The [`git::Reference`] name was invalid.
+    #[error(transparent)]
+    Name(#[from] ext::name::Error),
+    /// The user tried to fetch a tag, but the name provided does not
+    /// exist as a tag. This could mean that the tag does not exist
+    /// or that a branch or commit was provided by accident.
+    #[error("the reference `{0}` is not a tag")]
+    NotTag(RefLike),
+    /// The [`git::Reference`] could not successfully remove the namespace.
+    #[error(transparent)]
+    Strip(#[from] ext::name::StripPrefixError),
+    /// Failed to parse UTF-8 while building a [`Tag`].
+    #[error(transparent)]
+    Utf8(#[from] str::Utf8Error),
 }
 
 /// The static information of a [`git2::Tag`].
@@ -69,14 +52,14 @@ pub enum Tag {
         /// The Object ID for the `Tag`, i.e the SHA1 digest.
         id: Oid,
         /// The name that references this `Tag`.
-        name: TagName,
+        name: OneLevel,
     },
     /// An annotated git tag.
     Annotated {
         /// The Object ID for the `Tag`, i.e the SHA1 digest.
         id: Oid,
         /// The name that references this `Tag`.
-        name: TagName,
+        name: OneLevel,
         /// The named author of this `Tag`, if the `Tag` was annotated.
         tagger: Option<Author>,
         /// The message with this `Tag`, if the `Tag` was annotated.
@@ -85,6 +68,29 @@ pub enum Tag {
 }
 
 impl Tag {
+    /// Construct a [`Tag::Light`].
+    pub fn light(id: Oid, name: impl Into<OneLevel>) -> Tag {
+        Self::Light {
+            id,
+            name: name.into(),
+        }
+    }
+
+    /// Construct a [`Tag::Annotated`].
+    pub fn annotated(
+        id: Oid,
+        name: impl Into<OneLevel>,
+        tagger: impl Into<Option<Author>>,
+        message: impl Into<Option<String>>,
+    ) -> Tag {
+        Self::Annotated {
+            id,
+            name: name.into(),
+            tagger: tagger.into(),
+            message: message.into(),
+        }
+    }
+
     /// Get the `Oid` of the tag, regardless of its type.
     pub fn id(&self) -> Oid {
         match self {
@@ -94,7 +100,7 @@ impl Tag {
     }
 
     /// Get the `TagName` of the tag, regardless of its type.
-    pub fn name(&self) -> TagName {
+    pub fn name(&self) -> OneLevel {
         match self {
             Self::Light { name, .. } => name.clone(),
             Self::Annotated { name, .. } => name.clone(),
@@ -103,12 +109,12 @@ impl Tag {
 }
 
 impl<'repo> TryFrom<git2::Tag<'repo>> for Tag {
-    type Error = str::Utf8Error;
+    type Error = Error;
 
     fn try_from(tag: git2::Tag) -> Result<Self, Self::Error> {
         let id = tag.id();
 
-        let name = TagName::try_from(tag.name_bytes())?;
+        let name = ext::RefLike::try_from(tag.name_bytes())?;
 
         let tagger = tag.tagger().map(Author::try_from).transpose()?;
 
@@ -118,12 +124,7 @@ impl<'repo> TryFrom<git2::Tag<'repo>> for Tag {
             .transpose()?
             .map(|message| message.into());
 
-        Ok(Tag::Annotated {
-            id,
-            name,
-            tagger,
-            message,
-        })
+        Ok(Tag::annotated(id, name, tagger, message))
     }
 }
 
@@ -131,7 +132,8 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Tag {
     type Error = Error;
 
     fn try_from(reference: git2::Reference) -> Result<Self, Self::Error> {
-        let name = TagName::try_from(reference.name_bytes())?;
+        let name = ext::RefLike::try_from(reference.name_bytes())?;
+        let name = git::ext::remove_namespace(name)?;
 
         if !git::ext::is_tag(&reference) {
             return Err(Error::NotTag(name));
@@ -147,10 +149,7 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Tag {
                     && err.code() == git2::ErrorCode::InvalidSpec
                 {
                     let commit = reference.peel_to_commit()?;
-                    Ok(Tag::Light {
-                        id: commit.id(),
-                        name,
-                    })
+                    Ok(Tag::light(commit.id(), name))
                 } else {
                     Err(err.into())
                 }


### PR DESCRIPTION
The parsing of references in radicle-surf was quite ad-hoc and used
regexes. We wish to move to a more disciplined approach by using
radicle-git-ext's family of reference structures.

Admittedly, there's still some ad-hoc parsing or removing of prefixes
but it's still better than before.