### PR TITLE
Fix truncated remote branch names

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,7 @@ fn setup_fixtures() {
             "refs/tags/v0.2.0",
         ),
         (
-            "refs/namespaces/golden/refs/remotes/kickflip/heads/heelflip",
+            "refs/namespaces/golden/refs/remotes/kickflip/heads/heelflip/fakie",
             "refs/heads/dev",
         ),
         (

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -908,7 +908,7 @@ impl<'a> Browser<'a> {
     ///     branches,
     ///     vec![
     ///         Branch::local("banana"),
-    ///         Branch::remote("heelflip", "kickflip"),
+    ///         Branch::remote("heelflip/fakie", "kickflip"),
     ///     ]
     /// );
     /// #
@@ -1121,7 +1121,7 @@ mod tests {
 
             assert_eq!(expected_branches, branches);
 
-            let expected_branches: Vec<Branch> = vec![Branch::remote("heelflip", "kickflip")];
+            let expected_branches: Vec<Branch> = vec![Branch::remote("heelflip/fakie", "kickflip")];
             let mut branches = golden_browser.list_branches(Some(BranchType::Remote {
                 name: Some("kickflip".to_string()),
             }))?;
@@ -1579,6 +1579,7 @@ mod tests {
                     Branch::local("dev"),
                     Branch::remote("master", "origin"),
                     Branch::local("master"),
+                    Branch::remote("name/space", "origin"),
                     Branch::remote("pineapple", "banana"),
                 ]
             );

--- a/src/vcs/git.rs
+++ b/src/vcs/git.rs
@@ -1579,7 +1579,6 @@ mod tests {
                     Branch::local("dev"),
                     Branch::remote("master", "origin"),
                     Branch::local("master"),
-                    Branch::remote("name/space", "origin"),
                     Branch::remote("pineapple", "banana"),
                 ]
             );

--- a/src/vcs/git/branch.rs
+++ b/src/vcs/git/branch.rs
@@ -169,13 +169,14 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Branch {
         }
 
         if is_remote {
-            let mut split = name.0.split('/');
+            let mut split = name.0.splitn(2, '/');
             let remote_name = split
                 .next()
                 .ok_or_else(|| Error::ParseRemoteBranch(name.clone()))?;
             let name = split
                 .next()
                 .ok_or_else(|| Error::ParseRemoteBranch(name.clone()))?;
+
             Ok(Self {
                 name: BranchName(name.to_string()),
                 locality: BranchType::Remote {


### PR DESCRIPTION
Up until now surf would truncate branch names for remote branches, when
those included slashes.