### PR TITLE
source: revert identifier to peer_id

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -22,5 +22,5 @@ default-features = false
 features = []
 
 [dependencies.radicle-surf]
-path = "../surf"
+version = "^0.5.4"
 features = ["serialize"]


### PR DESCRIPTION
serialization means we need to keep the peer_id naming instead of
identitifier.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>