### PR TITLE
Depend on workspace version of crates

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -27,3 +27,4 @@ features = []
 [dependencies.radicle-surf]
 version = "^0.5.4"
 features = ["serialize"]
+path = "../surf"


### PR DESCRIPTION
This closes #178.

I tested this and it makes development between crates much easier. Local changes to `radicle-surf` now affect local builds of `radicle-source`.