### PR TITLE
source: backport branches in Commit

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "radicle-source"
 description = "A high level API for browsing source files"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 homepage = "https://github.com/radicle-dev/radicle-surf"

--- a/source/src/branch.rs
+++ b/source/src/branch.rs
@@ -33,6 +33,12 @@ impl From<String> for Branch {
     }
 }
 
+impl From<git::Branch> for Branch {
+    fn from(branch: git::Branch) -> Self {
+        Self(branch.name.to_string())
+    }
+}
+
 impl fmt::Display for Branch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/source/src/commit.rs
+++ b/source/src/commit.rs
@@ -27,7 +27,7 @@ use radicle_surf::{
     vcs::git::{self, Browser, Rev},
 };
 
-use crate::{error::Error, person::Person, revision::Revision};
+use crate::{branch::Branch, error::Error, person::Person, revision::Revision};
 
 /// Commit statistics.
 #[derive(Clone, Serialize)]
@@ -47,6 +47,8 @@ pub struct Commit {
     pub stats: Stats,
     /// The changeset introduced by this commit.
     pub diff: diff::Diff,
+    /// The list of branches this commit belongs to.
+    pub branches: Vec<Branch>,
 }
 
 /// Representation of a code commit.
@@ -159,6 +161,12 @@ pub fn commit(browser: &mut Browser<'_>, sha1: git2::Oid) -> Result<Commit, Erro
         }
     }
 
+    let branches = browser
+        .revision_branches(sha1)?
+        .into_iter()
+        .map(Branch::from)
+        .collect();
+
     Ok(Commit {
         header: Header::from(commit),
         stats: Stats {
@@ -166,6 +174,7 @@ pub fn commit(browser: &mut Browser<'_>, sha1: git2::Oid) -> Result<Commit, Erro
             deletions,
         },
         diff,
+        branches,
     })
 }
 


### PR DESCRIPTION
A backport of
https://github.com/radicle-dev/radicle-upstream/commit/0141921168c80d946422d93882a6522b5ed2506a
to add a field to Commit for the branches it belongs to.

This also bumps the version to publish the change to crates.io.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>