### PR TITLE
cargo: Bump surf crate version

### DIFF
--- a/source/Cargo.toml
+++ b/source/Cargo.toml
@@ -25,6 +25,6 @@ default-features = false
 features = []
 
 [dependencies.radicle-surf]
-version = "^0.5.4"
+version = "^0.5.5"
 features = ["serialize"]
 path = "../surf"

--- a/surf/Cargo.toml
+++ b/surf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "radicle-surf"
 description = "A code surfing library for VCS file systems"
 readme = "README.md"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 homepage = "https://github.com/radicle-dev/radicle-surf"


### PR DESCRIPTION
Source relies on changes which landed on lastest master in surf (namely
BranchSelector) but never made it to crates.io. This remedies that by
prepping 0.5.5 of the radicle-surf crate and have source depend on it.

Signed-off-by: Alexander Simmerl <a.simmerl@gmail.com>