### PR TITLE
surf: clear git-platinum fixtures before build

### DIFF
--- a/surf/build.rs
+++ b/surf/build.rs
@@ -17,6 +17,7 @@
 
 use std::{
     env,
+    fs,
     fs::File,
     io,
     path::{Path, PathBuf},
@@ -62,6 +63,10 @@ fn main() {
 }
 
 fn unpack(archive_path: impl AsRef<Path>, target: impl AsRef<Path>) -> Result<(), std::io::Error> {
+    let content = target.as_ref().join("git-platinum");
+    if content.exists() {
+        fs::remove_dir_all(content)?;
+    }
     let tar_gz = File::open(archive_path.as_ref())?;
     let tar = GzDecoder::new(tar_gz);
     let mut archive = Archive::new(tar);

--- a/surf/data/README.md
+++ b/surf/data/README.md
@@ -4,8 +4,9 @@
    `surf/data/mock-branches.txt`.
 2. Run `scripts/update-git-platinum.sh` from the repo root. This updates
    `surf/data/git-platinum.tgz`.
-3. Run the tests
-4. Commit your changes. We provide a template below so that we can easily
+3. Run `cargo build` to unpack the updated repo.
+4. Run the tests
+5. Commit your changes. We provide a template below so that we can easily
    identify changes to `git-platinum`. Please fill in the details that follow a
    comment (`#`):
    ```


### PR DESCRIPTION
We remove the `git-platinum` repo fixture when building `surf`. Otherwise files from the repo (e.g. refs) will not be removed when the archive is unpacked.

We also add an explicit step to the documentation to run `cargo build` before running the tests so that the repo is updated.