### PR TITLE
surf: fix committed timestamp

### DIFF
--- a/source/src/commit.rs
+++ b/source/src/commit.rs
@@ -96,7 +96,7 @@ impl From<&git::Commit> for Header {
                 name: commit.committer.name.clone(),
                 email: commit.committer.email.clone(),
             },
-            committer_time: commit.author.time,
+            committer_time: commit.committer.time,
         }
     }
 }


### PR DESCRIPTION
This seems like a bug.
We want to order the commit history in Upstream by committer time, just like the field says.

```
cargo test
   Compiling radicle-source v0.2.0 (/Users/rudolfs/work/radicle-surf/source)
    Finished test [unoptimized + debuginfo] target(s) in 1.15s
     Running unittests (target/debug/deps/radicle_source-1693e6f426c1d633)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/radicle_surf-52f3f2c5ace9f185)

running 59 tests
test file_system::directory::tests::find_file::file_does_not_exist ... ok
test file_system::directory::tests::directory_size::root_directory_files ... ok
test diff::tests::test_modify_file ... ok
test diff::tests::test_delete_directory ... ok
test diff::tests::test_modify_file_directory ... ok
test diff::tests::test_create_directory ... ok
test diff::tests::test_create_file ... ok
test diff::tests::test_delete_file ... ok
test file_system::directory::tests::find_file::in_root ... ok
test file_system::directory::tests::list_directory::root_files ... ok
test file_system::path::tests::path::split_last_root_and_foo ... ok
test file_system::path::tests::path::split_last_same_labels ... ok
test tree::tests::test_find_root_node ... ok
test tree::tests::test_fold_root_nodes ... ok
test file_system::directory::tests::properties::test_file_name_is_same_as_root ... ok
test tree::tests::test_find_branch_and_node ... ok
test file_system::directory::tests::properties::test_all_directories_and_files ... ok
test tree::tests::test_insert_branch ... ok
test tree::tests::test_insert_branches_and_node ... ok
test tree::tests::test_insert_replaces_branch_node ... ok
test tree::tests::test_insert_replaces_branch_with_node ... ok
test tree::tests::test_insert_replaces_node ... ok
test tree::tests::test_insert_replaces_node_with_branch ... ok
test tree::tests::test_insert_replaces_node_with_branch_foo ... ok
test tree::tests::test_insert_replaces_root_node ... ok
test tree::tests::test_insert_root_node ... ok
test tree::tests::test_insert_single_node ... ok
test tree::tests::test_insert_two_branches ... ok
test tree::tests::test_insert_two_nodes ... ok
test tree::tests::test_insert_two_nodes_out_of_order ... ok
test tree::tests::test_insert_with_prepending_branch_nodes ... ok
test tree::tests::test_insert_with_prepending_root_nodes ... ok
test tree::tests::test_is_empty ... ok
test tree::tests::test_maximum_by_branch_and_branch ... ok
test tree::tests::test_maximum_by_branch_and_node ... ok
test tree::tests::test_maximum_by_branch_nodes ... ok
test tree::tests::test_maximum_by_root_nodes ... ok
test vcs::git::reference::tests::parse_ref ... ok
test vcs::git::tests::diff::test_diff_serde ... ok
test vcs::git::tests::diff::test_initial_diff ... ok
test vcs::git::tests::last_commit::folder_svelte ... ok
test vcs::git::tests::diff::test_diff ... ok
test vcs::git::tests::last_commit::nest_directory ... ok
test vcs::git::tests::last_commit::can_get_last_commit_for_special_filenames ... ok
test vcs::git::tests::last_commit::readme_missing_and_memory ... ok
test vcs::git::tests::last_commit::root ... ok
test vcs::git::tests::rev::_master ... ok
test vcs::git::tests::rev::commit ... ok
test vcs::git::tests::rev::commit_parents ... ok
test vcs::git::tests::rev::commit_short ... ok
test vcs::git::tests::namespace::switch_to_banana ... ok
test vcs::git::tests::rev::tag ... ok
test vcs::git::tests::namespace::silver_namespace ... ok
test vcs::git::tests::namespace::me_namespace ... ok
test vcs::git::ext::tests::test_try_extract_refname ... ok
test vcs::git::tests::test_submodule_failure ... ok
test vcs::git::tests::namespace::golden_namespace ... ok
test vcs::git::tests::threading::basic_test ... ok
test file_system::directory::tests::properties::prop_test_all_directories_and_files ... ok

test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.40s

   Doc-tests radicle-source

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests radicle-surf

running 41 tests
test src/file_system/directory.rs - file_system::directory::Directory::size (line 455) ... ok
test src/file_system/directory.rs - file_system::directory::File::checksum (line 113) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::find_directory (line 382) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::find_file (line 346) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::current (line 420) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::iter (line 279) ... ok
test src/file_system.rs - file_system (line 24) ... ok
test src/file_system/directory.rs - file_system::directory::File::size (line 98) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::list_directory (line 217) ... ok
test src/file_system/path.rs - file_system::path::Label::is_root (line 74) ... ok
test src/file_system/path.rs - file_system::path::Label::root (line 57) ... ok
test src/file_system/path.rs - file_system::path::Path::append (line 244) ... ok
test src/file_system/path.rs - file_system::path::Path::from_labels (line 369) ... ok
test src/file_system/path.rs - file_system::path::Path::is_root (line 225) ... ok
test src/file_system/path.rs - file_system::path::Path::iter (line 300) ... ok
test src/file_system/path.rs - file_system::path::Path::pop (line 282) ... ok
test src/file_system/path.rs - file_system::path::Path::push (line 264) ... ok
test src/file_system/path.rs - file_system::path::Path::root (line 211) ... ok
test src/file_system/path.rs - file_system::path::Path::split_first (line 320) ... ok
test src/file_system/path.rs - file_system::path::Path::split_last (line 342) ... ok
test src/file_system/path.rs - file_system::path::Path::split_last (line 350) ... ok
test src/file_system/path.rs - file_system::path::Path::with_root (line 401) ... ok
test src/lib.rs - (line 31) ... ok
test src/vcs/git.rs - vcs::git (line 18) ... ok
test src/vcs/git.rs - vcs::git::Browser::branch (line 322) ... ok
test src/vcs/git.rs - vcs::git::Browser::branch (line 342) ... ok
test src/vcs/git.rs - vcs::git::Browser::commit (line 437) ... ok
test src/vcs/git.rs - vcs::git::Browser::extract_signature (line 881) ... ok
test src/vcs/git.rs - vcs::git::Browser::file_history (line 810) ... ok
test src/vcs/git.rs - vcs::git::Browser::get_stats (line 996) ... ok
test src/vcs/git.rs - vcs::git::Browser::head (line 287) ... ok
test src/vcs/git.rs - vcs::git::Browser::last_commit (line 762) ... ok
test src/vcs/git.rs - vcs::git::Browser::list_branches (line 561) ... ok
test src/vcs/git.rs - vcs::git::Browser::list_namespaces (line 725) ... ok
test src/vcs/git.rs - vcs::git::Browser::new (line 170) ... ok
test src/vcs/git.rs - vcs::git::Browser::list_tags (line 628) ... ok
test src/vcs/git.rs - vcs::git::Browser::oid (line 518) ... ok
test src/vcs/git.rs - vcs::git::Browser::new_with_namespace (line 198) ... ok
test src/vcs/git.rs - vcs::git::Browser::rev (line 483) ... ok
test src/vcs/git.rs - vcs::git::Browser::revision_branches (line 932) ... ok
test src/vcs/git.rs - vcs::git::Browser::tag (line 386) ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.50s
```