### PR TITLE
toolchain: move to stable

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,22 +5,22 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
-        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
+        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
+        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-unstable",
+        "branch": "release-21.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a73020b2a150322c9832b50baeb0296ba3b13dd7",
-        "sha256": "1s0ckc2qscrflr7bssd0s32zddp48dg5jk22w1dip2q2q7ks6cj0",
+        "rev": "0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00",
+        "sha256": "1mr2qgv5r2nmf6s3gqpcjj76zpsca6r61grzmqngwm0xlh958smx",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a73020b2a150322c9832b50baeb0296ba3b13dd7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0fd9ee1aa36ce865ad273f4f07fdc093adeb5c00.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b320f495d66fe8b2581d0d6f40a8dac6f9c6e6e9",
-        "sha256": "046cy1hjq4y3mk784x1hf8bdc5ip11z1f7f6wkycv5230038jrn2",
+        "rev": "37c9180fb097943e5427de21acba86a47c5f0f71",
+        "sha256": "03fcapbc9wj6a4wbp8c0y50akv212vy5sb2id535j94dxr7dnijm",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/b320f495d66fe8b2581d0d6f40a8dac6f9c6e6e9.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/37c9180fb097943e5427de21acba86a47c5f0f71.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-03-25
+stable

--- a/shell.nix
+++ b/shell.nix
@@ -4,21 +4,23 @@
   }
 }:
 let
-    rustToolChain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain);
-    rust = rustToolChain.override {
-        extensions = [ "rust-src" "rust-analysis" ];
-    };
+  stable = pkgs.rust-bin.stable.latest.default;
+  rust = stable.override {
+    extensions = [ "rust-src" "rust-analysis" ];
+  };
 in
 with pkgs;
 mkShell {
     name = "radicle-surf";
     buildInputs = [
+        cargo-deny
         cargo-expand
         cargo-watch
         # gnuplot for benchmark purposes
         gnuplot
         pkgconfig
         openssl
+        pkgs.rust-bin.nightly."2021-12-02".rustfmt
         ripgrep
         rust
         zlib

--- a/surf/src/diff.rs
+++ b/surf/src/diff.rs
@@ -217,7 +217,8 @@ impl Diff {
 
     // TODO: Direction of comparison is not obvious with this signature.
     // For now using conventional approach with the right being "newer".
-    pub fn diff(left: Directory, right: Directory) -> Result<Diff, DiffError> {
+    #[allow(clippy::self_named_constructors)]
+    pub fn diff(left: Directory, right: Directory) -> Result<Self, DiffError> {
         let mut diff = Diff::new();
         let path = Rc::new(RefCell::new(Path::from_labels(right.current(), &[])));
         Diff::collect_diff(&left, &right, &path, &mut diff)?;
@@ -437,7 +438,7 @@ impl Diff {
         parent_path: &Rc<RefCell<Path>>,
     ) -> Result<(), String> {
         let mut new_files: Vec<CreateFile> =
-            Diff::collect_files_from_entry(dc, &parent_path, CreateFile)?;
+            Diff::collect_files_from_entry(dc, parent_path, CreateFile)?;
         self.created.append(&mut new_files);
         Ok(())
     }
@@ -452,7 +453,7 @@ impl Diff {
         parent_path: &Rc<RefCell<Path>>,
     ) -> Result<(), String> {
         let mut new_files: Vec<DeleteFile> =
-            Diff::collect_files_from_entry(dc, &parent_path, DeleteFile)?;
+            Diff::collect_files_from_entry(dc, parent_path, DeleteFile)?;
         self.deleted.append(&mut new_files);
         Ok(())
     }

--- a/surf/src/tree.rs
+++ b/surf/src/tree.rs
@@ -101,14 +101,14 @@ impl<K, A> SubTree<K, A> {
                 SubTree::Node {
                     value: other_value, ..
                 },
-            ) => f(&value, &other_value),
+            ) => f(value, other_value),
             (SubTree::Branch { forest, .. }, SubTree::Node { value, .. }) => {
                 let max_forest = forest.maximum_by(f);
-                f(&max_forest, &value)
+                f(max_forest, value)
             },
             (SubTree::Node { value, .. }, SubTree::Branch { forest, .. }) => {
                 let max_forest = &forest.maximum_by(f);
-                f(&value, &max_forest)
+                f(value, max_forest)
             },
             (
                 SubTree::Branch { forest, .. },
@@ -119,7 +119,7 @@ impl<K, A> SubTree<K, A> {
             ) => {
                 let max_forest = forest.maximum_by(f);
                 let max_other_forest = other_forest.maximum_by(f);
-                f(&max_forest, &max_other_forest)
+                f(max_forest, max_other_forest)
             },
         }
     }

--- a/surf/src/vcs.rs
+++ b/surf/src/vcs.rs
@@ -111,7 +111,7 @@ impl<A> History<A> {
     {
         self.iter()
             .find(|artifact| {
-                let current_id = id_of(&artifact);
+                let current_id = id_of(artifact);
                 *identifier == current_id
             })
             .cloned()

--- a/surf/src/vcs/git.rs
+++ b/surf/src/vcs/git.rs
@@ -238,7 +238,7 @@ impl<'a> Browser<'a> {
 
     fn init(repository: RepositoryRef<'a>, history: History) -> Self {
         let snapshot = Box::new(|repository: &RepositoryRef<'a>, history: &History| {
-            let tree = Self::get_tree(&repository.repo_ref, history.0.first())?;
+            let tree = Self::get_tree(repository.repo_ref, history.0.first())?;
             Ok(directory::Directory::from_hash_map(tree))
         });
         vcs::Browser {
@@ -364,7 +364,7 @@ impl<'a> Browser<'a> {
     pub fn branch(&mut self, branch: Branch) -> Result<(), Error> {
         let name = BranchName(branch.name());
         self.set(self.repository.reference(branch, |reference| {
-            let is_branch = ext::is_branch(&reference) || reference.is_remote();
+            let is_branch = ext::is_branch(reference) || reference.is_remote();
             if !is_branch {
                 Some(Error::NotBranch(name))
             } else {
@@ -416,7 +416,7 @@ impl<'a> Browser<'a> {
     pub fn tag(&mut self, tag_name: TagName) -> Result<(), Error> {
         let name = tag_name.clone();
         self.set(self.repository.reference(tag_name, |reference| {
-            if !ext::is_tag(&reference) {
+            if !ext::is_tag(reference) {
                 Some(Error::NotTag(name))
             } else {
                 None
@@ -1051,7 +1051,7 @@ impl<'a> Browser<'a> {
             |s, entry| match Self::tree_entry_to_file_and_path(repo, s, entry) {
                 Ok((path, name, file)) => {
                     match file_paths_or_error.as_mut() {
-                        Ok(mut files) => Self::update_file_map(path, name, file, &mut files),
+                        Ok(files) => Self::update_file_map(path, name, file, files),
 
                         // We don't need to update, we want to keep the error.
                         Err(_err) => {},

--- a/surf/src/vcs/git/reference/glob.rs
+++ b/surf/src/vcs/git/reference/glob.rs
@@ -111,13 +111,13 @@ impl RefGlob {
                 let remotes = repo.repo_ref.references_glob(&format!(
                     "{}{}",
                     namespace_glob,
-                    Self::RemoteBranch { remote: None }.to_string()
+                    Self::RemoteBranch { remote: None }
                 ))?;
 
                 let locals = repo.repo_ref.references_glob(&format!(
                     "{}{}",
                     namespace_glob,
-                    &Self::LocalBranch.to_string()
+                    &Self::LocalBranch
                 ))?;
                 References {
                     inner: vec![remotes, locals],
@@ -127,24 +127,22 @@ impl RefGlob {
                 let remotes = repo.repo_ref.references_glob(&format!(
                     "{}{}",
                     namespace_glob,
-                    Self::RemoteTag { remote: None }.to_string()
+                    Self::RemoteTag { remote: None }
                 ))?;
 
                 let locals = repo.repo_ref.references_glob(&format!(
                     "{}{}",
                     namespace_glob,
-                    &Self::LocalTag.to_string()
+                    &Self::LocalTag
                 ))?;
                 References {
                     inner: vec![remotes, locals],
                 }
             },
             other => References {
-                inner: vec![repo.repo_ref.references_glob(&format!(
-                    "{}{}",
-                    namespace_glob,
-                    other.to_string()
-                ))?],
+                inner: vec![repo
+                    .repo_ref
+                    .references_glob(&format!("{}{}", namespace_glob, other,))?],
             },
         })
     }

--- a/surf/src/vcs/git/repo.rs
+++ b/surf/src/vcs/git/repo.rs
@@ -92,7 +92,7 @@ impl<'a> RepositoryRef<'a> {
     /// * [`Error::Git`]
     pub fn list_branches(&self, scope: RefScope) -> Result<Vec<Branch>, Error> {
         RefGlob::branch(scope)
-            .references(&self)?
+            .references(self)?
             .iter()
             .try_fold(vec![], |mut acc, reference| {
                 let branch = Branch::try_from(reference?)?;
@@ -109,7 +109,7 @@ impl<'a> RepositoryRef<'a> {
     /// * [`Error::Git`]
     pub fn list_tags(&self, scope: RefScope) -> Result<Vec<Tag>, Error> {
         RefGlob::tag(scope)
-            .references(&self)?
+            .references(self)?
             .iter()
             .try_fold(vec![], |mut acc, reference| {
                 let tag = Tag::try_from(reference?)?;
@@ -126,7 +126,7 @@ impl<'a> RepositoryRef<'a> {
     /// * [`Error::Git`]
     pub fn list_namespaces(&self) -> Result<Vec<Namespace>, Error> {
         let namespaces: Result<HashSet<Namespace>, Error> = RefGlob::Namespace
-            .references(&self)?
+            .references(self)?
             .iter()
             .try_fold(HashSet::new(), |mut acc, reference| {
                 let namespace = Namespace::try_from(reference?)?;
@@ -145,7 +145,7 @@ impl<'a> RepositoryRef<'a> {
             None => reference.into(),
             Some(namespace) => reference.into().namespaced(namespace),
         }
-        .find_ref(&self)?;
+        .find_ref(self)?;
 
         if let Some(err) = check(&reference) {
             return Err(err);
@@ -173,7 +173,7 @@ impl<'a> RepositoryRef<'a> {
     pub(super) fn rev_to_commit(&self, rev: &Rev) -> Result<git2::Commit, Error> {
         match rev {
             Rev::Oid(oid) => Ok(self.repo_ref.find_commit(*oid)?),
-            Rev::Ref(reference) => Ok(reference.find_ref(&self)?.peel_to_commit()?),
+            Rev::Ref(reference) => Ok(reference.find_ref(self)?.peel_to_commit()?),
         }
     }
 
@@ -264,7 +264,7 @@ impl<'a> RepositoryRef<'a> {
 
         references.try_for_each(|reference| {
             let reference = reference?;
-            self.reachable_from(&reference, &oid).and_then(|contains| {
+            self.reachable_from(&reference, oid).and_then(|contains| {
                 if contains {
                     let branch = Branch::try_from(reference)?;
                     contained_branches.push(branch);


### PR DESCRIPTION
I was getting errors with the nightly toolchain, seems to work on stable.

```
cargo test
   Compiling radicle-source v0.2.0 (/Users/rudolfs/work/radicle-surf/source)
    Finished test [unoptimized + debuginfo] target(s) in 0.50s
     Running unittests (target/debug/deps/radicle_source-1693e6f426c1d633)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/radicle_surf-52f3f2c5ace9f185)

running 59 tests
test file_system::directory::tests::find_file::file_does_not_exist ... ok
test file_system::directory::tests::directory_size::root_directory_files ... ok
test diff::tests::test_delete_directory ... ok
test diff::tests::test_delete_file ... ok
test diff::tests::test_modify_file ... ok
test diff::tests::test_modify_file_directory ... ok
test diff::tests::test_create_directory ... ok
test diff::tests::test_create_file ... ok
test file_system::directory::tests::find_file::in_root ... ok
test file_system::directory::tests::list_directory::root_files ... ok
test file_system::path::tests::path::split_last_root_and_foo ... ok
test file_system::path::tests::path::split_last_same_labels ... ok
test tree::tests::test_find_root_node ... ok
test tree::tests::test_fold_root_nodes ... ok
test file_system::directory::tests::properties::test_file_name_is_same_as_root ... ok
test tree::tests::test_find_branch_and_node ... ok
test tree::tests::test_insert_branch ... ok
test file_system::directory::tests::properties::test_all_directories_and_files ... ok
test tree::tests::test_insert_branches_and_node ... ok
test tree::tests::test_insert_replaces_branch_node ... ok
test tree::tests::test_insert_replaces_branch_with_node ... ok
test tree::tests::test_insert_replaces_node ... ok
test tree::tests::test_insert_replaces_node_with_branch ... ok
test tree::tests::test_insert_replaces_node_with_branch_foo ... ok
test tree::tests::test_insert_replaces_root_node ... ok
test tree::tests::test_insert_root_node ... ok
test tree::tests::test_insert_single_node ... ok
test tree::tests::test_insert_two_branches ... ok
test tree::tests::test_insert_two_nodes ... ok
test tree::tests::test_insert_two_nodes_out_of_order ... ok
test tree::tests::test_insert_with_prepending_branch_nodes ... ok
test tree::tests::test_insert_with_prepending_root_nodes ... ok
test tree::tests::test_is_empty ... ok
test tree::tests::test_maximum_by_branch_and_branch ... ok
test tree::tests::test_maximum_by_branch_and_node ... ok
test tree::tests::test_maximum_by_branch_nodes ... ok
test tree::tests::test_maximum_by_root_nodes ... ok
test vcs::git::reference::tests::parse_ref ... ok
test vcs::git::tests::diff::test_diff_serde ... ok
test vcs::git::tests::diff::test_initial_diff ... ok
test vcs::git::tests::last_commit::readme_missing_and_memory ... ok
test vcs::git::tests::last_commit::folder_svelte ... ok
test vcs::git::tests::diff::test_diff ... ok
test vcs::git::tests::last_commit::nest_directory ... ok
test vcs::git::tests::last_commit::can_get_last_commit_for_special_filenames ... ok
test vcs::git::tests::last_commit::root ... ok
test vcs::git::tests::rev::_master ... ok
test vcs::git::tests::rev::commit ... ok
test vcs::git::tests::rev::commit_parents ... ok
test vcs::git::tests::namespace::switch_to_banana ... ok
test vcs::git::tests::rev::tag ... ok
test vcs::git::tests::rev::commit_short ... ok
test vcs::git::tests::namespace::silver_namespace ... ok
test vcs::git::tests::namespace::me_namespace ... ok
test vcs::git::tests::test_submodule_failure ... ok
test vcs::git::ext::tests::test_try_extract_refname ... ok
test vcs::git::tests::namespace::golden_namespace ... ok
test vcs::git::tests::threading::basic_test ... ok
test file_system::directory::tests::properties::prop_test_all_directories_and_files ... ok

test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.44s

   Doc-tests radicle-source

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests radicle-surf

running 41 tests
test src/file_system/directory.rs - file_system::directory::Directory::size (line 455) ... ok
test src/file_system/directory.rs - file_system::directory::File::checksum (line 113) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::current (line 420) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::find_file (line 346) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::find_directory (line 382) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::iter (line 279) ... ok
test src/file_system/directory.rs - file_system::directory::Directory::list_directory (line 217) ... ok
test src/file_system.rs - file_system (line 24) ... ok
test src/file_system/directory.rs - file_system::directory::File::size (line 98) ... ok
test src/file_system/path.rs - file_system::path::Label::is_root (line 74) ... ok
test src/file_system/path.rs - file_system::path::Label::root (line 57) ... ok
test src/file_system/path.rs - file_system::path::Path::append (line 244) ... ok
test src/file_system/path.rs - file_system::path::Path::from_labels (line 369) ... ok
test src/file_system/path.rs - file_system::path::Path::is_root (line 225) ... ok
test src/file_system/path.rs - file_system::path::Path::iter (line 300) ... ok
test src/file_system/path.rs - file_system::path::Path::pop (line 282) ... ok
test src/file_system/path.rs - file_system::path::Path::push (line 264) ... ok
test src/file_system/path.rs - file_system::path::Path::root (line 211) ... ok
test src/file_system/path.rs - file_system::path::Path::split_first (line 320) ... ok
test src/file_system/path.rs - file_system::path::Path::split_last (line 342) ... ok
test src/file_system/path.rs - file_system::path::Path::split_last (line 350) ... ok
test src/file_system/path.rs - file_system::path::Path::with_root (line 401) ... ok
test src/lib.rs - (line 31) ... ok
test src/vcs/git.rs - vcs::git (line 18) ... ok
test src/vcs/git.rs - vcs::git::Browser::branch (line 322) ... ok
test src/vcs/git.rs - vcs::git::Browser::branch (line 342) ... ok
test src/vcs/git.rs - vcs::git::Browser::commit (line 437) ... ok
test src/vcs/git.rs - vcs::git::Browser::extract_signature (line 881) ... ok
test src/vcs/git.rs - vcs::git::Browser::file_history (line 810) ... ok
test src/vcs/git.rs - vcs::git::Browser::get_stats (line 996) ... ok
test src/vcs/git.rs - vcs::git::Browser::head (line 287) ... ok
test src/vcs/git.rs - vcs::git::Browser::last_commit (line 762) ... ok
test src/vcs/git.rs - vcs::git::Browser::list_branches (line 561) ... ok
test src/vcs/git.rs - vcs::git::Browser::list_namespaces (line 725) ... ok
test src/vcs/git.rs - vcs::git::Browser::new (line 170) ... ok
test src/vcs/git.rs - vcs::git::Browser::list_tags (line 628) ... ok
test src/vcs/git.rs - vcs::git::Browser::new_with_namespace (line 198) ... ok
test src/vcs/git.rs - vcs::git::Browser::oid (line 518) ... ok
test src/vcs/git.rs - vcs::git::Browser::rev (line 483) ... ok
test src/vcs/git.rs - vcs::git::Browser::revision_branches (line 932) ... ok
test src/vcs/git.rs - vcs::git::Browser::tag (line 386) ... ok

test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 6.44s
```

Error on nightly:
```
error[E0658]: use of unstable library feature 'nonzero_leading_trailing_zeros'
   --> /Users/rudolfs/.cargo/registry/src/github.com-1ecc6299db9ec823/semver-1.0.4/src/identifier.rs:265:40
    |
265 |     let zero_bits_on_string_end = repr.leading_zeros();
    |                                        ^^^^^^^^^^^^^
    |
    = note: see issue #79143 <https://github.com/rust-lang/rust/issues/79143> for more information
    = help: add `#![feature(nonzero_leading_trailing_zeros)]` to the crate attributes to enable

error[E0658]: use of unstable library feature 'nonzero_leading_trailing_zeros'
   --> /Users/rudolfs/.cargo/registry/src/github.com-1ecc6299db9ec823/semver-1.0.4/src/identifier.rs:354:37
    |
354 |     let len_bits = usize_bits - len.leading_zeros() as usize;
    |                                     ^^^^^^^^^^^^^
    |
    = note: see issue #79143 <https://github.com/rust-lang/rust/issues/79143> for more information
    = help: add `#![feature(nonzero_leading_trailing_zeros)]` to the crate attributes to enable

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0658`.
error: could not compile `semver`

To learn more, run the command again with --verbose.
```