### PR TITLE
Add diffs for created and deleted files

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "9cb7ef336bb71fd1ca84fc7f2dff15ef4b033f2a",
-        "sha256": "1ajyqr8zka1zlb25jx1v4xys3zqmdy3prbm1vxlid6ah27a8qnzh",
+        "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
+        "sha256": "090l219mzc0gi33i3psgph6s2pwsc8qy4lyrqjdj4qzkvmaj65a7",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/9cb7ef336bb71fd1ca84fc7f2dff15ef4b033f2a.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25da763feee71991124b1698c16d29d665755f9d",
-        "sha256": "09q0w7424zjy5cpi61j0l00z668w2dbxil5vnl32k6nsdjmsg6bk",
+        "rev": "f96729212602f15a6a226d2f27f5de70492ad095",
+        "sha256": "1l9y427cirmdjbf0wxhhk09yg6wmk1844xa5gvzw16xm2p3wfgjq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/25da763feee71991124b1698c16d29d665755f9d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f96729212602f15a6a226d2f27f5de70492ad095.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7e9f7b17e523ae93c12b678d94c66700f37e21bc",
-        "sha256": "0pmla0vqfzj5a1lqz8xbyw3dri4xky0jlk4f54kn1jh2przf9f6d",
+        "rev": "9eea93067eff400846c36f57b7499df9ef428ba0",
+        "sha256": "0vbjld45m6ig19i5zcwlv86m09dnq8msf072s3j3bc6kym2aiy4m",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/7e9f7b17e523ae93c12b678d94c66700f37e21bc.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/9eea93067eff400846c36f57b7499df9ef428ba0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -13,11 +13,13 @@ with pkgs;
 mkShell {
     name = "radicle-surf";
     buildInputs = [
+        clang
         cargo-deny
         cargo-expand
         cargo-watch
         # gnuplot for benchmark purposes
         gnuplot
+        lld
         pkgconfig
         openssl
         pkgs.rust-bin.nightly."2021-12-02".rustfmt

--- a/source/src/commit.rs
+++ b/source/src/commit.rs
@@ -161,6 +161,30 @@ pub fn commit(browser: &mut Browser<'_>, sha1: git2::Oid) -> Result<Commit, Erro
         }
     }
 
+    for file in &diff.created {
+        if let diff::FileDiff::Plain { ref hunks } = file.diff {
+            for hunk in hunks.iter() {
+                for line in &hunk.lines {
+                    if let diff::LineDiff::Addition { .. } = line {
+                        additions += 1
+                    }
+                }
+            }
+        }
+    }
+
+    for file in &diff.deleted {
+        if let diff::FileDiff::Plain { ref hunks } = file.diff {
+            for hunk in hunks.iter() {
+                for line in &hunk.lines {
+                    if let diff::LineDiff::Deletion { .. } = line {
+                        deletions += 1
+                    }
+                }
+            }
+        }
+    }
+
     let branches = browser
         .revision_branches(sha1)?
         .into_iter()

--- a/surf/Cargo.toml
+++ b/surf/Cargo.toml
@@ -27,7 +27,7 @@ gh-actions = []
 either = "1.5"
 nom = "6"
 nonempty = "0.5"
-regex = "1.3"
+regex = ">= 1.5.5"
 serde = { features = ["serde_derive"], optional = true, version = "1" }
 thiserror = "1.0"
 

--- a/surf/examples/diff.rs
+++ b/surf/examples/diff.rs
@@ -48,16 +48,9 @@ fn main() {
     let base_directory = get_directory_or_exit(&browser);
 
     let now = Instant::now();
-    match Diff::diff(base_directory, head_directory) {
-        Ok(diff) => {
-            let elapsed_nanos = now.elapsed().as_nanos();
-            print_diff_summary(&diff, elapsed_nanos);
-        },
-        Err(e) => {
-            println!("Failed to build diff: {:?}", e);
-            std::process::exit(1);
-        },
-    };
+    let elapsed_nanos = now.elapsed().as_nanos();
+    let diff = Diff::diff(base_directory, head_directory);
+    print_diff_summary(&diff, elapsed_nanos);
 }
 
 fn get_options_or_exit() -> Options {

--- a/surf/examples/diff.rs
+++ b/surf/examples/diff.rs
@@ -122,10 +122,10 @@ fn get_directory_or_exit(browser: &git::Browser) -> Directory {
 
 fn print_diff_summary(diff: &Diff, elapsed_nanos: u128) {
     diff.created.iter().for_each(|created| {
-        println!("+++ {}", created.0);
+        println!("+++ {}", created.path);
     });
     diff.deleted.iter().for_each(|deleted| {
-        println!("--- {}", deleted.0);
+        println!("--- {}", deleted.path);
     });
     diff.modified.iter().for_each(|modified| {
         println!("mod {}", modified.path);

--- a/surf/src/diff/git.rs
+++ b/surf/src/diff/git.rs
@@ -17,47 +17,74 @@
 
 use std::convert::TryFrom;
 
-use thiserror::Error;
-
 use crate::{
-    diff::{self, Diff, EofNewLine, Hunk, Line, LineDiff},
+    diff::{self, Diff, EofNewLine, Hunk, Hunks, Line, LineDiff},
     file_system::Path,
-    vcs,
 };
 
-/// A Git diff error.
-#[derive(Debug, PartialEq, Error)]
-#[non_exhaustive]
-pub enum Error {
-    /// A The path of a file isn't available.
-    #[error("couldn't retrieve file path")]
-    PathUnavailable,
-    /// A patch is unavailable.
-    #[error("couldn't retrieve patch for {0}")]
-    PatchUnavailable(Path),
-    /// A Git delta type isn't currently handled.
-    #[error("git delta type is not handled")]
-    DeltaUnhandled(git2::Delta),
-    /// A Git `DiffLine` is invalid.
-    #[error("invalid `git2::DiffLine`")]
-    InvalidLineDiff,
+pub mod error {
+    use thiserror::Error;
+
+    use crate::file_system::{self, Path};
+
+    #[derive(Debug, Error, PartialEq)]
+    #[non_exhaustive]
+    pub enum LineDiff {
+        /// A Git `DiffLine` is invalid.
+        #[error(
+            "invalid `git2::DiffLine` which contains no line numbers for either side of the diff"
+        )]
+        Invalid,
+    }
+
+    #[derive(Debug, Error, PartialEq)]
+    #[non_exhaustive]
+    pub enum Hunk {
+        #[error(transparent)]
+        Git(#[from] git2::Error),
+        #[error(transparent)]
+        Line(#[from] LineDiff),
+    }
+
+    /// A Git diff error.
+    #[derive(Debug, PartialEq, Error)]
+    #[non_exhaustive]
+    pub enum Diff {
+        /// A Git delta type isn't currently handled.
+        #[error("git delta type is not handled")]
+        DeltaUnhandled(git2::Delta),
+        #[error(transparent)]
+        FileSystem(#[from] file_system::Error),
+        #[error(transparent)]
+        Git(#[from] git2::Error),
+        #[error(transparent)]
+        Hunk(#[from] Hunk),
+        #[error(transparent)]
+        Line(#[from] LineDiff),
+        /// A patch is unavailable.
+        #[error("couldn't retrieve patch for {0}")]
+        PatchUnavailable(Path),
+        /// A The path of a file isn't available.
+        #[error("couldn't retrieve file path")]
+        PathUnavailable,
+    }
 }
 
 impl<'a> TryFrom<git2::DiffLine<'a>> for LineDiff {
-    type Error = Error;
+    type Error = error::LineDiff;
 
     fn try_from(line: git2::DiffLine) -> Result<Self, Self::Error> {
         match (line.old_lineno(), line.new_lineno()) {
             (None, Some(n)) => Ok(Self::addition(line.content().to_owned(), n)),
             (Some(n), None) => Ok(Self::deletion(line.content().to_owned(), n)),
             (Some(l), Some(r)) => Ok(Self::context(line.content().to_owned(), l, r)),
-            (None, None) => Err(Error::InvalidLineDiff),
+            (None, None) => Err(error::LineDiff::Invalid),
         }
     }
 }
 
 impl<'a> TryFrom<git2::Diff<'a>> for Diff {
-    type Error = vcs::git::error::Error;
+    type Error = error::Diff;
 
     fn try_from(git_diff: git2::Diff) -> Result<Diff, Self::Error> {
         use git2::{Delta, Patch};
@@ -68,59 +95,51 @@ impl<'a> TryFrom<git2::Diff<'a>> for Diff {
             match delta.status() {
                 Delta::Added => {
                     let diff_file = delta.new_file();
-                    let path = diff_file.path().ok_or(diff::git::Error::PathUnavailable)?;
+                    let path = diff_file.path().ok_or(error::Diff::PathUnavailable)?;
                     let path = Path::try_from(path.to_path_buf())?;
 
                     let patch = Patch::from_diff(&git_diff, idx)?;
                     if let Some(patch) = patch {
-                        let mut hunks: Vec<Hunk> = Vec::new();
-
-                        for h in 0..patch.num_hunks() {
-                            let (hunk, hunk_lines) = patch.hunk(h)?;
-                            let header = Line(hunk.header().to_owned());
-                            let mut lines: Vec<LineDiff> = Vec::new();
-
-                            for l in 0..hunk_lines {
-                                let line = patch.line_in_hunk(h, l)?;
-                                let line = LineDiff::try_from(line)?;
-                                lines.push(line);
-                            }
-                            hunks.push(Hunk { header, lines });
-                        }
-                        diff.add_created_file(path, diff::FileDiff::Plain { hunks });
+                        diff.add_created_file(
+                            path,
+                            diff::FileDiff::Plain {
+                                hunks: Hunks::try_from(patch)?,
+                            },
+                        );
                     } else {
-                        diff.add_created_file(path, diff::FileDiff::Plain { hunks: vec![] });
+                        diff.add_created_file(
+                            path,
+                            diff::FileDiff::Plain {
+                                hunks: Hunks::default(),
+                            },
+                        );
                     }
                 },
                 Delta::Deleted => {
                     let diff_file = delta.old_file();
-                    let path = diff_file.path().ok_or(diff::git::Error::PathUnavailable)?;
+                    let path = diff_file.path().ok_or(error::Diff::PathUnavailable)?;
                     let path = Path::try_from(path.to_path_buf())?;
 
                     let patch = Patch::from_diff(&git_diff, idx)?;
                     if let Some(patch) = patch {
-                        let mut hunks: Vec<Hunk> = Vec::new();
-
-                        for h in 0..patch.num_hunks() {
-                            let (hunk, hunk_lines) = patch.hunk(h)?;
-                            let header = Line(hunk.header().to_owned());
-                            let mut lines: Vec<LineDiff> = Vec::new();
-
-                            for l in 0..hunk_lines {
-                                let line = patch.line_in_hunk(h, l)?;
-                                let line = LineDiff::try_from(line)?;
-                                lines.push(line);
-                            }
-                            hunks.push(Hunk { header, lines });
-                        }
-                        diff.add_deleted_file(path, diff::FileDiff::Plain { hunks });
+                        diff.add_deleted_file(
+                            path,
+                            diff::FileDiff::Plain {
+                                hunks: Hunks::try_from(patch)?,
+                            },
+                        );
                     } else {
-                        diff.add_deleted_file(path, diff::FileDiff::Plain { hunks: vec![] });
+                        diff.add_deleted_file(
+                            path,
+                            diff::FileDiff::Plain {
+                                hunks: Hunks::default(),
+                            },
+                        );
                     }
                 },
                 Delta::Modified => {
                     let diff_file = delta.new_file();
-                    let path = diff_file.path().ok_or(diff::git::Error::PathUnavailable)?;
+                    let path = diff_file.path().ok_or(error::Diff::PathUnavailable)?;
                     let path = Path::try_from(path.to_path_buf())?;
 
                     let patch = Patch::from_diff(&git_diff, idx)?;
@@ -168,18 +187,18 @@ impl<'a> TryFrom<git2::Diff<'a>> for Diff {
                     } else if diff_file.is_binary() {
                         diff.add_modified_binary_file(path);
                     } else {
-                        return Err(diff::git::Error::PatchUnavailable(path).into());
+                        return Err(error::Diff::PatchUnavailable(path));
                     }
                 },
                 Delta::Renamed => {
                     let old = delta
                         .old_file()
                         .path()
-                        .ok_or(diff::git::Error::PathUnavailable)?;
+                        .ok_or(error::Diff::PathUnavailable)?;
                     let new = delta
                         .new_file()
                         .path()
-                        .ok_or(diff::git::Error::PathUnavailable)?;
+                        .ok_or(error::Diff::PathUnavailable)?;
 
                     let old_path = Path::try_from(old.to_path_buf())?;
                     let new_path = Path::try_from(new.to_path_buf())?;
@@ -190,11 +209,11 @@ impl<'a> TryFrom<git2::Diff<'a>> for Diff {
                     let old = delta
                         .old_file()
                         .path()
-                        .ok_or(diff::git::Error::PathUnavailable)?;
+                        .ok_or(error::Diff::PathUnavailable)?;
                     let new = delta
                         .new_file()
                         .path()
-                        .ok_or(diff::git::Error::PathUnavailable)?;
+                        .ok_or(error::Diff::PathUnavailable)?;
 
                     let old_path = Path::try_from(old.to_path_buf())?;
                     let new_path = Path::try_from(new.to_path_buf())?;
@@ -202,7 +221,7 @@ impl<'a> TryFrom<git2::Diff<'a>> for Diff {
                     diff.add_copied_file(old_path, new_path);
                 },
                 status => {
-                    return Err(diff::git::Error::DeltaUnhandled(status).into());
+                    return Err(error::Diff::DeltaUnhandled(status));
                 },
             }
         }

--- a/surf/src/vcs/git.rs
+++ b/surf/src/vcs/git.rs
@@ -1561,7 +1561,7 @@ mod tests {
                             lines: vec![
                                 LineDiff::addition(b"This repository is a data source for the Upstream front-end tests.\n".to_vec(), 1),
                             ]
-                        }]
+                        }].into()
                     },
                 }],
                 deleted: vec![],
@@ -1605,7 +1605,7 @@ mod tests {
                                 LineDiff::addition(b"This repository is a data source for the Upstream front-end tests and the\n".to_vec(), 1),
                                 LineDiff::addition(b"[`radicle-surf`](https://github.com/radicle-dev/git-platinum) unit tests.\n".to_vec(), 2),
                             ]
-                        }]
+                        }].into()
                     },
                     eof: None,
                 }]
@@ -1621,7 +1621,7 @@ mod tests {
             use file_system::*;
 
             let diff = Diff {
-                created: vec![CreateFile{path: unsound::path::new("LICENSE"), diff: FileDiff::Plain { hunks: vec![] }}],
+                created: vec![CreateFile{path: unsound::path::new("LICENSE"), diff: FileDiff::Plain { hunks: Hunks::default() }}],
                 deleted: vec![],
                 moved: vec![
                     MoveFile {
@@ -1641,7 +1641,7 @@ mod tests {
                                 LineDiff::addition(b"[`radicle-surf`](https://github.com/radicle-dev/git-platinum) unit tests.\n".to_vec(), 2),
                                 LineDiff::context(b"\n".to_vec(), 3, 4),
                             ]
-                        }]
+                        }].into()
                     },
                     eof: None,
                 }]

--- a/surf/src/vcs/git.rs
+++ b/surf/src/vcs/git.rs
@@ -1553,9 +1553,17 @@ mod tests {
             let diff = bro.initial_diff(oid)?;
 
             let expected_diff = Diff {
-                created: vec![CreateFile(Path::with_root(&[unsound::label::new(
-                    "README.md",
-                )]))],
+                created: vec![CreateFile {
+                    path: Path::with_root(&[unsound::label::new("README.md")]),
+                    diff: FileDiff::Plain {
+                        hunks: vec![Hunk {
+                            header: Line(b"@@ -0,0 +1 @@\n".to_vec()),
+                            lines: vec![
+                                LineDiff::addition(b"This repository is a data source for the Upstream front-end tests.\n".to_vec(), 1),
+                            ]
+                        }]
+                    },
+                }],
                 deleted: vec![],
                 moved: vec![],
                 copied: vec![],
@@ -1613,7 +1621,7 @@ mod tests {
             use file_system::*;
 
             let diff = Diff {
-                created: vec![CreateFile(unsound::path::new("LICENSE"))],
+                created: vec![CreateFile{path: unsound::path::new("LICENSE"), diff: FileDiff::Plain { hunks: vec![] }}],
                 deleted: vec![],
                 moved: vec![
                     MoveFile {
@@ -1641,7 +1649,11 @@ mod tests {
 
             let eof: Option<u8> = None;
             let json = serde_json::json!({
-                "created": ["LICENSE"],
+                "created": [{"path": "LICENSE", "diff": {
+                        "type": "plain",
+                        "hunks": []
+                    },
+                }],
                 "deleted": [],
                 "moved": [{ "oldPath": "CONTRIBUTING", "newPath": "CONTRIBUTING.md" }],
                 "copied": [],

--- a/surf/src/vcs/git/error.rs
+++ b/surf/src/vcs/git/error.rs
@@ -84,7 +84,7 @@ pub enum Error {
     PathNotFound(file_system::Path),
     /// An error that comes from performing a *diff* operations.
     #[error(transparent)]
-    Diff(#[from] diff::git::Error),
+    Diff(#[from] diff::git::error::Diff),
     /// A wrapper around the generic [`git2::Error`].
     #[error(transparent)]
     Git(#[from] git2::Error),

--- a/surf/src/vcs/git/repo.rs
+++ b/surf/src/vcs/git/repo.rs
@@ -157,12 +157,13 @@ impl<'a> RepositoryRef<'a> {
     /// Get the [`Diff`] between two commits.
     pub fn diff(&self, from: Oid, to: Oid) -> Result<Diff, Error> {
         self.diff_commits(None, Some(from), to)
-            .and_then(Diff::try_from)
+            .and_then(|diff| Diff::try_from(diff).map_err(Error::from))
     }
 
     /// Get the [`Diff`] of a commit with no parents.
     pub fn initial_diff(&self, oid: Oid) -> Result<Diff, Error> {
-        self.diff_commits(None, None, oid).and_then(Diff::try_from)
+        self.diff_commits(None, None, oid)
+            .and_then(|diff| Diff::try_from(diff).map_err(Error::from))
     }
 
     /// Parse an [`Oid`] from the given string.


### PR DESCRIPTION
We'd like to show the file contents for created and deleted files when reviewing code, otherwise we can't do full review within our app.

Here's how it looks in Upstream:
<img width="1728" alt="Screenshot 2022-06-07 at 10 51 15" src="https://user-images.githubusercontent.com/158411/172338754-3de662a4-2021-4fb3-99c1-8ee3309688c7.png">

